### PR TITLE
feat: implement materialized views, partitioning, and DDL statement parsing (Issue #69)

### DIFF
--- a/pkg/sql/keywords/keywords.go
+++ b/pkg/sql/keywords/keywords.go
@@ -121,6 +121,35 @@ var ADDITIONAL_KEYWORDS = []Keyword{
 	{Word: "MATCHED", Type: models.TokenTypeKeyword, Reserved: true, ReservedForTableAlias: false},
 	{Word: "SOURCE", Type: models.TokenTypeKeyword, Reserved: false, ReservedForTableAlias: false},
 	{Word: "TARGET", Type: models.TokenTypeKeyword, Reserved: false, ReservedForTableAlias: false},
+	// DDL statement keywords (Phase 4 - Materialized Views & Partitioning)
+	{Word: "CREATE", Type: models.TokenTypeKeyword, Reserved: true, ReservedForTableAlias: true},
+	{Word: "DROP", Type: models.TokenTypeKeyword, Reserved: true, ReservedForTableAlias: true},
+	{Word: "ALTER", Type: models.TokenTypeKeyword, Reserved: true, ReservedForTableAlias: true},
+	{Word: "TABLE", Type: models.TokenTypeKeyword, Reserved: true, ReservedForTableAlias: true},
+	{Word: "INDEX", Type: models.TokenTypeKeyword, Reserved: true, ReservedForTableAlias: true},
+	// MATERIALIZED is PostgreSQL-specific, defined in dialect.go
+	{Word: "REFRESH", Type: models.TokenTypeKeyword, Reserved: true, ReservedForTableAlias: true},
+	{Word: "CONCURRENTLY", Type: models.TokenTypeKeyword, Reserved: true, ReservedForTableAlias: false},
+	{Word: "CASCADE", Type: models.TokenTypeKeyword, Reserved: true, ReservedForTableAlias: false},
+	{Word: "RESTRICT", Type: models.TokenTypeKeyword, Reserved: true, ReservedForTableAlias: false},
+	// DATA is commonly used as table/column name, handled as identifier
+	{Word: "TEMPORARY", Type: models.TokenTypeKeyword, Reserved: true, ReservedForTableAlias: false},
+	// TEMP is commonly used as identifier (e.g., CTE name "temp"), handled via isTokenMatch in parser
+	{Word: "REPLACE", Type: models.TokenTypeKeyword, Reserved: true, ReservedForTableAlias: false},
+	{Word: "EXISTS", Type: models.TokenTypeKeyword, Reserved: true, ReservedForTableAlias: false},
+	{Word: "IF", Type: models.TokenTypeKeyword, Reserved: true, ReservedForTableAlias: false},
+	// Partitioning keywords
+	{Word: "HASH", Type: models.TokenTypeKeyword, Reserved: false, ReservedForTableAlias: false},
+	{Word: "LIST", Type: models.TokenTypeKeyword, Reserved: false, ReservedForTableAlias: false},
+	{Word: "VALUES", Type: models.TokenTypeKeyword, Reserved: true, ReservedForTableAlias: false},
+	{Word: "LESS", Type: models.TokenTypeKeyword, Reserved: false, ReservedForTableAlias: false},
+	{Word: "THAN", Type: models.TokenTypeKeyword, Reserved: false, ReservedForTableAlias: false},
+	{Word: "MAXVALUE", Type: models.TokenTypeKeyword, Reserved: false, ReservedForTableAlias: false},
+	{Word: "TABLESPACE", Type: models.TokenTypeKeyword, Reserved: false, ReservedForTableAlias: false},
+	{Word: "CHECK", Type: models.TokenTypeKeyword, Reserved: true, ReservedForTableAlias: false},
+	{Word: "OPTION", Type: models.TokenTypeKeyword, Reserved: false, ReservedForTableAlias: false},
+	{Word: "CASCADED", Type: models.TokenTypeKeyword, Reserved: false, ReservedForTableAlias: false},
+	{Word: "LOCAL", Type: models.TokenTypeKeyword, Reserved: false, ReservedForTableAlias: false},
 }
 
 // addKeywordsWithCategory is a helper method to add multiple keywords
@@ -142,6 +171,17 @@ func New(dialect SQLDialect, ignoreCase bool) *Keywords {
 	k.CompoundKeywords["CROSS JOIN"] = models.TokenTypeKeyword
 	k.CompoundKeywords["NATURAL JOIN"] = models.TokenTypeKeyword
 	k.CompoundKeywords["GROUPING SETS"] = models.TokenTypeKeyword // SQL-99 grouping operation
+	// Materialized views and DDL compound keywords
+	k.CompoundKeywords["MATERIALIZED VIEW"] = models.TokenTypeKeyword
+	k.CompoundKeywords["IF EXISTS"] = models.TokenTypeKeyword
+	k.CompoundKeywords["IF NOT EXISTS"] = models.TokenTypeKeyword
+	k.CompoundKeywords["OR REPLACE"] = models.TokenTypeKeyword
+	k.CompoundKeywords["WITH DATA"] = models.TokenTypeKeyword
+	k.CompoundKeywords["WITH NO DATA"] = models.TokenTypeKeyword
+	// Partitioning compound keywords
+	k.CompoundKeywords["PARTITION BY"] = models.TokenTypeKeyword
+	k.CompoundKeywords["LESS THAN"] = models.TokenTypeKeyword
+	k.CompoundKeywords["CHECK OPTION"] = models.TokenTypeKeyword
 
 	// Add standard keywords
 	k.addKeywordsWithCategory(RESERVED_FOR_TABLE_ALIAS)

--- a/pkg/sql/parser/ddl.go
+++ b/pkg/sql/parser/ddl.go
@@ -1,0 +1,819 @@
+// Package parser - ddl.go
+// DDL statement parsing: CREATE, DROP, REFRESH for views, materialized views, tables, and indexes.
+
+package parser
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/ajitpratap0/GoSQLX/pkg/sql/ast"
+)
+
+// isTokenMatch checks if the current token matches the given keyword
+// This handles both keyword tokens and identifier tokens with matching literal values
+// (needed because some keywords like DATA, NO may be tokenized as identifiers)
+func (p *Parser) isTokenMatch(keyword string) bool {
+	upperKeyword := strings.ToUpper(keyword)
+	// Check if token type matches the keyword directly
+	if strings.ToUpper(string(p.currentToken.Type)) == upperKeyword {
+		return true
+	}
+	// Check if it's an identifier with matching literal (case-insensitive)
+	if p.currentToken.Type == "IDENT" && strings.ToUpper(p.currentToken.Literal) == upperKeyword {
+		return true
+	}
+	return false
+}
+
+// parseCreateStatement parses CREATE statements (TABLE, VIEW, MATERIALIZED VIEW, INDEX)
+func (p *Parser) parseCreateStatement() (ast.Statement, error) {
+	// Check for modifiers: OR REPLACE, TEMPORARY, TEMP
+	orReplace := false
+	temporary := false
+
+	for {
+		if p.currentToken.Type == "OR" {
+			p.advance() // Consume OR
+			if p.currentToken.Type != "REPLACE" {
+				return nil, p.expectedError("REPLACE after OR")
+			}
+			p.advance() // Consume REPLACE
+			orReplace = true
+		} else if p.currentToken.Type == "TEMPORARY" || p.isTokenMatch("TEMP") {
+			p.advance() // Consume TEMPORARY/TEMP
+			temporary = true
+		} else {
+			break
+		}
+	}
+
+	// Determine object type
+	switch p.currentToken.Type {
+	case "MATERIALIZED":
+		p.advance() // Consume MATERIALIZED
+		if p.currentToken.Type != "VIEW" {
+			return nil, p.expectedError("VIEW after MATERIALIZED")
+		}
+		p.advance() // Consume VIEW
+		return p.parseCreateMaterializedView()
+
+	case "VIEW":
+		p.advance() // Consume VIEW
+		return p.parseCreateView(orReplace, temporary)
+
+	case "TABLE":
+		p.advance() // Consume TABLE
+		return p.parseCreateTable(temporary)
+
+	case "INDEX":
+		p.advance()                      // Consume INDEX
+		return p.parseCreateIndex(false) // Not unique
+
+	case "UNIQUE":
+		p.advance() // Consume UNIQUE
+		if p.currentToken.Type != "INDEX" {
+			return nil, p.expectedError("INDEX after UNIQUE")
+		}
+		p.advance()                     // Consume INDEX
+		return p.parseCreateIndex(true) // Unique
+
+	default:
+		return nil, p.expectedError("TABLE, VIEW, MATERIALIZED VIEW, or INDEX after CREATE")
+	}
+}
+
+// parseCreateView parses CREATE [OR REPLACE] [TEMPORARY] VIEW statement
+func (p *Parser) parseCreateView(orReplace, temporary bool) (*ast.CreateViewStatement, error) {
+	stmt := &ast.CreateViewStatement{
+		OrReplace: orReplace,
+		Temporary: temporary,
+	}
+
+	// Check for IF NOT EXISTS
+	if p.currentToken.Type == "IF" {
+		p.advance() // Consume IF
+		if p.currentToken.Type != "NOT" {
+			return nil, p.expectedError("NOT after IF")
+		}
+		p.advance() // Consume NOT
+		if p.currentToken.Type != "EXISTS" {
+			return nil, p.expectedError("EXISTS after NOT")
+		}
+		p.advance() // Consume EXISTS
+		stmt.IfNotExists = true
+	}
+
+	// Parse view name
+	if p.currentToken.Type != "IDENT" {
+		return nil, p.expectedError("view name")
+	}
+	stmt.Name = p.currentToken.Literal
+	p.advance()
+
+	// Parse optional column list
+	if p.currentToken.Type == "(" {
+		p.advance() // Consume (
+		for {
+			if p.currentToken.Type != "IDENT" {
+				return nil, p.expectedError("column name")
+			}
+			stmt.Columns = append(stmt.Columns, p.currentToken.Literal)
+			p.advance()
+
+			if p.currentToken.Type == "," {
+				p.advance() // Consume comma
+				continue
+			}
+			break
+		}
+		if p.currentToken.Type != ")" {
+			return nil, p.expectedError(")")
+		}
+		p.advance() // Consume )
+	}
+
+	// Expect AS
+	if p.currentToken.Type != "AS" {
+		return nil, p.expectedError("AS")
+	}
+	p.advance() // Consume AS
+
+	// Parse the SELECT statement
+	if p.currentToken.Type != "SELECT" {
+		return nil, p.expectedError("SELECT")
+	}
+	p.advance() // Consume SELECT
+
+	query, err := p.parseSelectWithSetOperations()
+	if err != nil {
+		return nil, fmt.Errorf("error parsing view query: %v", err)
+	}
+	stmt.Query = query
+
+	// Parse optional WITH CHECK OPTION
+	if p.currentToken.Type == "WITH" {
+		p.advance() // Consume WITH
+		if p.currentToken.Type == "CHECK" {
+			p.advance() // Consume CHECK
+			if p.currentToken.Type == "OPTION" {
+				p.advance() // Consume OPTION
+				stmt.WithOption = "CHECK OPTION"
+			}
+		} else if p.currentToken.Type == "CASCADED" {
+			p.advance() // Consume CASCADED
+			if p.currentToken.Type == "CHECK" {
+				p.advance() // Consume CHECK
+				if p.currentToken.Type == "OPTION" {
+					p.advance() // Consume OPTION
+					stmt.WithOption = "CASCADED CHECK OPTION"
+				}
+			}
+		} else if p.currentToken.Type == "LOCAL" {
+			p.advance() // Consume LOCAL
+			if p.currentToken.Type == "CHECK" {
+				p.advance() // Consume CHECK
+				if p.currentToken.Type == "OPTION" {
+					p.advance() // Consume OPTION
+					stmt.WithOption = "LOCAL CHECK OPTION"
+				}
+			}
+		}
+	}
+
+	return stmt, nil
+}
+
+// parseCreateMaterializedView parses CREATE MATERIALIZED VIEW statement
+func (p *Parser) parseCreateMaterializedView() (*ast.CreateMaterializedViewStatement, error) {
+	stmt := &ast.CreateMaterializedViewStatement{}
+
+	// Check for IF NOT EXISTS
+	if p.currentToken.Type == "IF" {
+		p.advance() // Consume IF
+		if p.currentToken.Type != "NOT" {
+			return nil, p.expectedError("NOT after IF")
+		}
+		p.advance() // Consume NOT
+		if p.currentToken.Type != "EXISTS" {
+			return nil, p.expectedError("EXISTS after NOT")
+		}
+		p.advance() // Consume EXISTS
+		stmt.IfNotExists = true
+	}
+
+	// Parse view name
+	if p.currentToken.Type != "IDENT" {
+		return nil, p.expectedError("materialized view name")
+	}
+	stmt.Name = p.currentToken.Literal
+	p.advance()
+
+	// Parse optional column list
+	if p.currentToken.Type == "(" {
+		p.advance() // Consume (
+		for {
+			if p.currentToken.Type != "IDENT" {
+				return nil, p.expectedError("column name")
+			}
+			stmt.Columns = append(stmt.Columns, p.currentToken.Literal)
+			p.advance()
+
+			if p.currentToken.Type == "," {
+				p.advance() // Consume comma
+				continue
+			}
+			break
+		}
+		if p.currentToken.Type != ")" {
+			return nil, p.expectedError(")")
+		}
+		p.advance() // Consume )
+	}
+
+	// Parse optional TABLESPACE
+	if p.currentToken.Type == "TABLESPACE" {
+		p.advance() // Consume TABLESPACE
+		if p.currentToken.Type != "IDENT" {
+			return nil, p.expectedError("tablespace name")
+		}
+		stmt.Tablespace = p.currentToken.Literal
+		p.advance()
+	}
+
+	// Expect AS
+	if p.currentToken.Type != "AS" {
+		return nil, p.expectedError("AS")
+	}
+	p.advance() // Consume AS
+
+	// Parse the SELECT statement
+	if p.currentToken.Type != "SELECT" {
+		return nil, p.expectedError("SELECT")
+	}
+	p.advance() // Consume SELECT
+
+	query, err := p.parseSelectWithSetOperations()
+	if err != nil {
+		return nil, fmt.Errorf("error parsing materialized view query: %v", err)
+	}
+	stmt.Query = query
+
+	// Parse optional WITH [NO] DATA
+	// Note: DATA and NO may be tokenized as IDENT since they're common identifiers
+	if p.currentToken.Type == "WITH" {
+		p.advance() // Consume WITH
+		if p.isTokenMatch("NO") {
+			p.advance() // Consume NO
+			if !p.isTokenMatch("DATA") {
+				return nil, p.expectedError("DATA after NO")
+			}
+			p.advance() // Consume DATA
+			withData := false
+			stmt.WithData = &withData
+		} else if p.isTokenMatch("DATA") {
+			p.advance() // Consume DATA
+			withData := true
+			stmt.WithData = &withData
+		}
+	}
+
+	return stmt, nil
+}
+
+// parseCreateTable parses CREATE TABLE statement with partitioning support
+func (p *Parser) parseCreateTable(temporary bool) (*ast.CreateTableStatement, error) {
+	stmt := &ast.CreateTableStatement{
+		Temporary: temporary,
+	}
+
+	// Check for IF NOT EXISTS
+	if p.currentToken.Type == "IF" {
+		p.advance() // Consume IF
+		if p.currentToken.Type != "NOT" {
+			return nil, p.expectedError("NOT after IF")
+		}
+		p.advance() // Consume NOT
+		if p.currentToken.Type != "EXISTS" {
+			return nil, p.expectedError("EXISTS after NOT")
+		}
+		p.advance() // Consume EXISTS
+		stmt.IfNotExists = true
+	}
+
+	// Parse table name
+	if p.currentToken.Type != "IDENT" {
+		return nil, p.expectedError("table name")
+	}
+	stmt.Name = p.currentToken.Literal
+	p.advance()
+
+	// Expect opening parenthesis for column definitions
+	if p.currentToken.Type != "(" {
+		return nil, p.expectedError("(")
+	}
+	p.advance() // Consume (
+
+	// Parse column definitions and constraints
+	for {
+		// Check for table-level constraints
+		if p.currentToken.Type == "PRIMARY" || p.currentToken.Type == "FOREIGN" ||
+			p.currentToken.Type == "UNIQUE" || p.currentToken.Type == "CHECK" ||
+			p.currentToken.Type == "CONSTRAINT" {
+			constraint, err := p.parseTableConstraint()
+			if err != nil {
+				return nil, err
+			}
+			stmt.Constraints = append(stmt.Constraints, *constraint)
+		} else {
+			// Parse column definition
+			colDef, err := p.parseColumnDef()
+			if err != nil {
+				return nil, err
+			}
+			stmt.Columns = append(stmt.Columns, *colDef)
+		}
+
+		// Check for more definitions
+		if p.currentToken.Type == "," {
+			p.advance() // Consume comma
+			continue
+		}
+		break
+	}
+
+	// Expect closing parenthesis
+	if p.currentToken.Type != ")" {
+		return nil, p.expectedError(")")
+	}
+	p.advance() // Consume )
+
+	// Parse optional PARTITION BY clause
+	if p.currentToken.Type == "PARTITION" {
+		p.advance() // Consume PARTITION
+		if p.currentToken.Type != "BY" {
+			return nil, p.expectedError("BY after PARTITION")
+		}
+		p.advance() // Consume BY
+
+		partitionBy, err := p.parsePartitionByClause()
+		if err != nil {
+			return nil, err
+		}
+		stmt.PartitionBy = partitionBy
+
+		// Parse partition definitions if present
+		if p.currentToken.Type == "(" {
+			p.advance() // Consume (
+			for {
+				partDef, err := p.parsePartitionDefinition()
+				if err != nil {
+					return nil, err
+				}
+				stmt.Partitions = append(stmt.Partitions, *partDef)
+
+				if p.currentToken.Type == "," {
+					p.advance() // Consume comma
+					continue
+				}
+				break
+			}
+			if p.currentToken.Type != ")" {
+				return nil, p.expectedError(")")
+			}
+			p.advance() // Consume )
+		}
+	}
+
+	// Parse optional table options
+	for p.currentToken.Type == "ENGINE" || p.currentToken.Type == "CHARSET" ||
+		p.currentToken.Type == "COLLATE" || p.currentToken.Type == "COMMENT" {
+		opt := ast.TableOption{Name: p.currentToken.Literal}
+		p.advance()
+		if p.currentToken.Type == "=" {
+			p.advance() // Consume =
+		}
+		if p.currentToken.Type == "IDENT" || p.currentToken.Type == "STRING" {
+			opt.Value = p.currentToken.Literal
+			p.advance()
+		}
+		stmt.Options = append(stmt.Options, opt)
+	}
+
+	return stmt, nil
+}
+
+// parsePartitionByClause parses PARTITION BY RANGE/LIST/HASH (columns)
+func (p *Parser) parsePartitionByClause() (*ast.PartitionBy, error) {
+	partitionBy := &ast.PartitionBy{}
+
+	// Parse partition type
+	switch p.currentToken.Type {
+	case "RANGE":
+		partitionBy.Type = "RANGE"
+		p.advance()
+	case "LIST":
+		partitionBy.Type = "LIST"
+		p.advance()
+	case "HASH":
+		partitionBy.Type = "HASH"
+		p.advance()
+	default:
+		return nil, p.expectedError("RANGE, LIST, or HASH")
+	}
+
+	// Expect opening parenthesis
+	if p.currentToken.Type != "(" {
+		return nil, p.expectedError("(")
+	}
+	p.advance() // Consume (
+
+	// Parse column list
+	for {
+		if p.currentToken.Type != "IDENT" {
+			return nil, p.expectedError("column name")
+		}
+		partitionBy.Columns = append(partitionBy.Columns, p.currentToken.Literal)
+		p.advance()
+
+		if p.currentToken.Type == "," {
+			p.advance() // Consume comma
+			continue
+		}
+		break
+	}
+
+	// Expect closing parenthesis
+	if p.currentToken.Type != ")" {
+		return nil, p.expectedError(")")
+	}
+	p.advance() // Consume )
+
+	return partitionBy, nil
+}
+
+// parsePartitionDefinition parses a single partition definition
+func (p *Parser) parsePartitionDefinition() (*ast.PartitionDefinition, error) {
+	partDef := &ast.PartitionDefinition{}
+
+	// Expect PARTITION keyword
+	if p.currentToken.Type != "PARTITION" {
+		return nil, p.expectedError("PARTITION")
+	}
+	p.advance() // Consume PARTITION
+
+	// Parse partition name
+	if p.currentToken.Type != "IDENT" {
+		return nil, p.expectedError("partition name")
+	}
+	partDef.Name = p.currentToken.Literal
+	p.advance()
+
+	// Parse VALUES clause
+	if p.currentToken.Type != "VALUES" {
+		return nil, p.expectedError("VALUES")
+	}
+	p.advance() // Consume VALUES
+
+	// Parse value specification
+	if p.currentToken.Type == "LESS" {
+		p.advance() // Consume LESS
+		if p.currentToken.Type != "THAN" {
+			return nil, p.expectedError("THAN after LESS")
+		}
+		p.advance() // Consume THAN
+		partDef.Type = "LESS THAN"
+
+		// Parse value or MAXVALUE
+		if p.currentToken.Type == "(" {
+			p.advance() // Consume (
+			if p.currentToken.Type == "MAXVALUE" {
+				partDef.LessThan = &ast.Identifier{Name: "MAXVALUE"}
+				p.advance()
+			} else {
+				expr, err := p.parseExpression()
+				if err != nil {
+					return nil, err
+				}
+				partDef.LessThan = expr
+			}
+			if p.currentToken.Type != ")" {
+				return nil, p.expectedError(")")
+			}
+			p.advance() // Consume )
+		} else if p.currentToken.Type == "MAXVALUE" {
+			partDef.LessThan = &ast.Identifier{Name: "MAXVALUE"}
+			p.advance()
+		}
+	} else if p.currentToken.Type == "IN" {
+		p.advance() // Consume IN
+		partDef.Type = "IN"
+
+		// Parse value list
+		if p.currentToken.Type != "(" {
+			return nil, p.expectedError("(")
+		}
+		p.advance() // Consume (
+
+		for {
+			expr, err := p.parseExpression()
+			if err != nil {
+				return nil, err
+			}
+			partDef.InValues = append(partDef.InValues, expr)
+
+			if p.currentToken.Type == "," {
+				p.advance() // Consume comma
+				continue
+			}
+			break
+		}
+
+		if p.currentToken.Type != ")" {
+			return nil, p.expectedError(")")
+		}
+		p.advance() // Consume )
+	} else if p.currentToken.Type == "FROM" {
+		p.advance() // Consume FROM
+		partDef.Type = "FROM TO"
+
+		// Parse FROM value
+		if p.currentToken.Type != "(" {
+			return nil, p.expectedError("(")
+		}
+		p.advance() // Consume (
+		fromExpr, err := p.parseExpression()
+		if err != nil {
+			return nil, err
+		}
+		partDef.From = fromExpr
+		if p.currentToken.Type != ")" {
+			return nil, p.expectedError(")")
+		}
+		p.advance() // Consume )
+
+		// Expect TO
+		if p.currentToken.Type != "TO" {
+			return nil, p.expectedError("TO")
+		}
+		p.advance() // Consume TO
+
+		// Parse TO value
+		if p.currentToken.Type != "(" {
+			return nil, p.expectedError("(")
+		}
+		p.advance() // Consume (
+		toExpr, err := p.parseExpression()
+		if err != nil {
+			return nil, err
+		}
+		partDef.To = toExpr
+		if p.currentToken.Type != ")" {
+			return nil, p.expectedError(")")
+		}
+		p.advance() // Consume )
+	}
+
+	// Parse optional TABLESPACE
+	if p.currentToken.Type == "TABLESPACE" {
+		p.advance() // Consume TABLESPACE
+		if p.currentToken.Type != "IDENT" {
+			return nil, p.expectedError("tablespace name")
+		}
+		partDef.Tablespace = p.currentToken.Literal
+		p.advance()
+	}
+
+	return partDef, nil
+}
+
+// parseCreateIndex parses CREATE [UNIQUE] INDEX statement
+func (p *Parser) parseCreateIndex(unique bool) (*ast.CreateIndexStatement, error) {
+	stmt := &ast.CreateIndexStatement{
+		Unique: unique,
+	}
+
+	// Check for IF NOT EXISTS
+	if p.currentToken.Type == "IF" {
+		p.advance() // Consume IF
+		if p.currentToken.Type != "NOT" {
+			return nil, p.expectedError("NOT after IF")
+		}
+		p.advance() // Consume NOT
+		if p.currentToken.Type != "EXISTS" {
+			return nil, p.expectedError("EXISTS after NOT")
+		}
+		p.advance() // Consume EXISTS
+		stmt.IfNotExists = true
+	}
+
+	// Parse index name
+	if p.currentToken.Type != "IDENT" {
+		return nil, p.expectedError("index name")
+	}
+	stmt.Name = p.currentToken.Literal
+	p.advance()
+
+	// Expect ON
+	if p.currentToken.Type != "ON" {
+		return nil, p.expectedError("ON")
+	}
+	p.advance() // Consume ON
+
+	// Parse table name
+	if p.currentToken.Type != "IDENT" {
+		return nil, p.expectedError("table name")
+	}
+	stmt.Table = p.currentToken.Literal
+	p.advance()
+
+	// Parse optional USING
+	if p.currentToken.Type == "USING" {
+		p.advance() // Consume USING
+		if p.currentToken.Type != "IDENT" {
+			return nil, p.expectedError("index method")
+		}
+		stmt.Using = p.currentToken.Literal
+		p.advance()
+	}
+
+	// Expect opening parenthesis
+	if p.currentToken.Type != "(" {
+		return nil, p.expectedError("(")
+	}
+	p.advance() // Consume (
+
+	// Parse column list
+	for {
+		col := ast.IndexColumn{}
+		if p.currentToken.Type != "IDENT" {
+			return nil, p.expectedError("column name")
+		}
+		col.Column = p.currentToken.Literal
+		p.advance()
+
+		// Parse optional direction
+		if p.currentToken.Type == "ASC" {
+			col.Direction = "ASC"
+			p.advance()
+		} else if p.currentToken.Type == "DESC" {
+			col.Direction = "DESC"
+			p.advance()
+		}
+
+		// Parse optional NULLS LAST
+		if p.currentToken.Type == "NULLS" {
+			p.advance() // Consume NULLS
+			if p.currentToken.Type == "LAST" {
+				col.NullsLast = true
+				p.advance()
+			} else if p.currentToken.Type == "FIRST" {
+				p.advance()
+			}
+		}
+
+		stmt.Columns = append(stmt.Columns, col)
+
+		if p.currentToken.Type == "," {
+			p.advance() // Consume comma
+			continue
+		}
+		break
+	}
+
+	// Expect closing parenthesis
+	if p.currentToken.Type != ")" {
+		return nil, p.expectedError(")")
+	}
+	p.advance() // Consume )
+
+	// Parse optional WHERE clause (partial index)
+	if p.currentToken.Type == "WHERE" {
+		p.advance() // Consume WHERE
+		whereClause, err := p.parseExpression()
+		if err != nil {
+			return nil, err
+		}
+		stmt.Where = whereClause
+	}
+
+	return stmt, nil
+}
+
+// parseDropStatement parses DROP statements (TABLE, VIEW, MATERIALIZED VIEW, INDEX)
+func (p *Parser) parseDropStatement() (*ast.DropStatement, error) {
+	stmt := &ast.DropStatement{}
+
+	// Determine object type
+	switch p.currentToken.Type {
+	case "MATERIALIZED":
+		p.advance() // Consume MATERIALIZED
+		if p.currentToken.Type != "VIEW" {
+			return nil, p.expectedError("VIEW after MATERIALIZED")
+		}
+		p.advance() // Consume VIEW
+		stmt.ObjectType = "MATERIALIZED VIEW"
+
+	case "VIEW":
+		p.advance() // Consume VIEW
+		stmt.ObjectType = "VIEW"
+
+	case "TABLE":
+		p.advance() // Consume TABLE
+		stmt.ObjectType = "TABLE"
+
+	case "INDEX":
+		p.advance() // Consume INDEX
+		stmt.ObjectType = "INDEX"
+
+	default:
+		return nil, p.expectedError("TABLE, VIEW, MATERIALIZED VIEW, or INDEX after DROP")
+	}
+
+	// Check for IF EXISTS
+	if p.currentToken.Type == "IF" {
+		p.advance() // Consume IF
+		if p.currentToken.Type != "EXISTS" {
+			return nil, p.expectedError("EXISTS after IF")
+		}
+		p.advance() // Consume EXISTS
+		stmt.IfExists = true
+	}
+
+	// Parse object names (can be comma-separated)
+	for {
+		if p.currentToken.Type != "IDENT" {
+			return nil, p.expectedError("object name")
+		}
+		stmt.Names = append(stmt.Names, p.currentToken.Literal)
+		p.advance()
+
+		if p.currentToken.Type == "," {
+			p.advance() // Consume comma
+			continue
+		}
+		break
+	}
+
+	// Parse optional CASCADE/RESTRICT
+	if p.currentToken.Type == "CASCADE" {
+		stmt.CascadeType = "CASCADE"
+		p.advance()
+	} else if p.currentToken.Type == "RESTRICT" {
+		stmt.CascadeType = "RESTRICT"
+		p.advance()
+	}
+
+	return stmt, nil
+}
+
+// parseRefreshStatement parses REFRESH MATERIALIZED VIEW statement
+func (p *Parser) parseRefreshStatement() (*ast.RefreshMaterializedViewStatement, error) {
+	// Expect MATERIALIZED
+	if p.currentToken.Type != "MATERIALIZED" {
+		return nil, p.expectedError("MATERIALIZED after REFRESH")
+	}
+	p.advance() // Consume MATERIALIZED
+
+	// Expect VIEW
+	if p.currentToken.Type != "VIEW" {
+		return nil, p.expectedError("VIEW after MATERIALIZED")
+	}
+	p.advance() // Consume VIEW
+
+	stmt := &ast.RefreshMaterializedViewStatement{}
+
+	// Check for CONCURRENTLY
+	if p.currentToken.Type == "CONCURRENTLY" {
+		stmt.Concurrently = true
+		p.advance()
+	}
+
+	// Parse view name
+	if p.currentToken.Type != "IDENT" {
+		return nil, p.expectedError("materialized view name")
+	}
+	stmt.Name = p.currentToken.Literal
+	p.advance()
+
+	// Parse optional WITH [NO] DATA
+	// Note: DATA and NO may be tokenized as IDENT since they're common identifiers
+	if p.currentToken.Type == "WITH" {
+		p.advance() // Consume WITH
+		if p.isTokenMatch("NO") {
+			p.advance() // Consume NO
+			if !p.isTokenMatch("DATA") {
+				return nil, p.expectedError("DATA after NO")
+			}
+			p.advance() // Consume DATA
+			withData := false
+			stmt.WithData = &withData
+		} else if p.isTokenMatch("DATA") {
+			p.advance() // Consume DATA
+			withData := true
+			stmt.WithData = &withData
+		}
+	}
+
+	return stmt, nil
+}

--- a/pkg/sql/parser/ddl_test.go
+++ b/pkg/sql/parser/ddl_test.go
@@ -1,0 +1,619 @@
+// Package parser - ddl_test.go
+// Tests for DDL statement parsing: CREATE, DROP, REFRESH for views, materialized views, tables, and indexes.
+
+package parser
+
+import (
+	"testing"
+
+	"github.com/ajitpratap0/GoSQLX/pkg/models"
+	"github.com/ajitpratap0/GoSQLX/pkg/sql/ast"
+	"github.com/ajitpratap0/GoSQLX/pkg/sql/token"
+	"github.com/ajitpratap0/GoSQLX/pkg/sql/tokenizer"
+)
+
+// parseDDLSQL is a helper to tokenize and parse SQL for DDL testing
+func parseDDLSQL(t *testing.T, sql string) *ast.AST {
+	t.Helper()
+
+	tkz := tokenizer.GetTokenizer()
+	defer tokenizer.PutTokenizer(tkz)
+
+	tokens, err := tkz.Tokenize([]byte(sql))
+	if err != nil {
+		t.Fatalf("Failed to tokenize: %v", err)
+	}
+
+	convertedTokens := convertTokensForDDL(tokens)
+
+	parser := &Parser{}
+	astObj, err := parser.Parse(convertedTokens)
+	if err != nil {
+		t.Fatalf("Failed to parse: %v", err)
+	}
+
+	return astObj
+}
+
+// convertTokensForDDL converts tokenizer tokens to parser tokens
+func convertTokensForDDL(tokens []models.TokenWithSpan) []token.Token {
+	result := make([]token.Token, 0, len(tokens))
+	for _, t := range tokens {
+		var tokenType token.Type
+
+		switch t.Token.Type {
+		case models.TokenTypeIdentifier:
+			tokenType = "IDENT"
+		case models.TokenTypeKeyword:
+			// Use the keyword value as the token type (CREATE, DROP, etc.)
+			tokenType = token.Type(t.Token.Value)
+		case models.TokenTypeString:
+			tokenType = "STRING"
+		case models.TokenTypeNumber:
+			tokenType = "INT"
+		case models.TokenTypeOperator:
+			tokenType = token.Type(t.Token.Value)
+		case models.TokenTypeLParen:
+			tokenType = "("
+		case models.TokenTypeRParen:
+			tokenType = ")"
+		case models.TokenTypeComma:
+			tokenType = ","
+		case models.TokenTypePeriod:
+			tokenType = "."
+		case models.TokenTypeEq:
+			tokenType = "="
+		case models.TokenTypeSemicolon:
+			tokenType = ";"
+		default:
+			if t.Token.Value != "" {
+				tokenType = token.Type(t.Token.Value)
+			}
+		}
+
+		if tokenType != "" && t.Token.Value != "" {
+			result = append(result, token.Token{
+				Type:    tokenType,
+				Literal: t.Token.Value,
+			})
+		}
+	}
+	return result
+}
+
+func TestParser_CreateView(t *testing.T) {
+	tests := []struct {
+		name      string
+		sql       string
+		wantName  string
+		wantCols  int
+		orReplace bool
+		temporary bool
+	}{
+		{
+			name:     "simple CREATE VIEW",
+			sql:      "CREATE VIEW user_summary AS SELECT id, name FROM users",
+			wantName: "user_summary",
+		},
+		{
+			name:      "CREATE OR REPLACE VIEW",
+			sql:       "CREATE OR REPLACE VIEW user_summary AS SELECT id, name FROM users",
+			wantName:  "user_summary",
+			orReplace: true,
+		},
+		{
+			name:      "CREATE TEMPORARY VIEW",
+			sql:       "CREATE TEMPORARY VIEW temp_users AS SELECT id FROM users",
+			wantName:  "temp_users",
+			temporary: true,
+		},
+		{
+			name:     "CREATE VIEW with column list",
+			sql:      "CREATE VIEW user_info (user_id, user_name) AS SELECT id, name FROM users",
+			wantName: "user_info",
+			wantCols: 2,
+		},
+		{
+			name:     "CREATE VIEW IF NOT EXISTS",
+			sql:      "CREATE VIEW IF NOT EXISTS user_view AS SELECT id FROM users",
+			wantName: "user_view",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := parseDDLSQL(t, tt.sql)
+			defer ast.ReleaseAST(result)
+
+			if len(result.Statements) != 1 {
+				t.Fatalf("expected 1 statement, got %d", len(result.Statements))
+			}
+
+			stmt, ok := result.Statements[0].(*ast.CreateViewStatement)
+			if !ok {
+				t.Fatalf("expected CreateViewStatement, got %T", result.Statements[0])
+			}
+
+			if stmt.Name != tt.wantName {
+				t.Errorf("expected view name %q, got %q", tt.wantName, stmt.Name)
+			}
+
+			if stmt.OrReplace != tt.orReplace {
+				t.Errorf("expected OrReplace=%v, got %v", tt.orReplace, stmt.OrReplace)
+			}
+
+			if stmt.Temporary != tt.temporary {
+				t.Errorf("expected Temporary=%v, got %v", tt.temporary, stmt.Temporary)
+			}
+
+			if tt.wantCols > 0 && len(stmt.Columns) != tt.wantCols {
+				t.Errorf("expected %d columns, got %d", tt.wantCols, len(stmt.Columns))
+			}
+
+			if stmt.Query == nil {
+				t.Error("expected Query to be non-nil")
+			}
+		})
+	}
+}
+
+func TestParser_CreateMaterializedView(t *testing.T) {
+	tests := []struct {
+		name        string
+		sql         string
+		wantName    string
+		wantCols    int
+		ifNotExists bool
+		withData    *bool
+	}{
+		{
+			name:     "simple CREATE MATERIALIZED VIEW",
+			sql:      "CREATE MATERIALIZED VIEW sales_summary AS SELECT region, amount FROM sales",
+			wantName: "sales_summary",
+		},
+		{
+			name:        "CREATE MATERIALIZED VIEW IF NOT EXISTS",
+			sql:         "CREATE MATERIALIZED VIEW IF NOT EXISTS mv_test AS SELECT id FROM users",
+			wantName:    "mv_test",
+			ifNotExists: true,
+		},
+		{
+			name:     "CREATE MATERIALIZED VIEW with column list",
+			sql:      "CREATE MATERIALIZED VIEW sales_mv (reg, total) AS SELECT region, amount FROM sales",
+			wantName: "sales_mv",
+			wantCols: 2,
+		},
+		{
+			name:     "CREATE MATERIALIZED VIEW WITH DATA",
+			sql:      "CREATE MATERIALIZED VIEW mv_data AS SELECT id FROM users WITH DATA",
+			wantName: "mv_data",
+			withData: boolPtr(true),
+		},
+		{
+			name:     "CREATE MATERIALIZED VIEW WITH NO DATA",
+			sql:      "CREATE MATERIALIZED VIEW mv_nodata AS SELECT id FROM users WITH NO DATA",
+			wantName: "mv_nodata",
+			withData: boolPtr(false),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := parseDDLSQL(t, tt.sql)
+			defer ast.ReleaseAST(result)
+
+			if len(result.Statements) != 1 {
+				t.Fatalf("expected 1 statement, got %d", len(result.Statements))
+			}
+
+			stmt, ok := result.Statements[0].(*ast.CreateMaterializedViewStatement)
+			if !ok {
+				t.Fatalf("expected CreateMaterializedViewStatement, got %T", result.Statements[0])
+			}
+
+			if stmt.Name != tt.wantName {
+				t.Errorf("expected view name %q, got %q", tt.wantName, stmt.Name)
+			}
+
+			if stmt.IfNotExists != tt.ifNotExists {
+				t.Errorf("expected IfNotExists=%v, got %v", tt.ifNotExists, stmt.IfNotExists)
+			}
+
+			if tt.wantCols > 0 && len(stmt.Columns) != tt.wantCols {
+				t.Errorf("expected %d columns, got %d", tt.wantCols, len(stmt.Columns))
+			}
+
+			if stmt.Query == nil {
+				t.Error("expected Query to be non-nil")
+			}
+
+			if tt.withData != nil {
+				if stmt.WithData == nil {
+					t.Error("expected WithData to be non-nil")
+				} else if *stmt.WithData != *tt.withData {
+					t.Errorf("expected WithData=%v, got %v", *tt.withData, *stmt.WithData)
+				}
+			}
+		})
+	}
+}
+
+func TestParser_RefreshMaterializedView(t *testing.T) {
+	tests := []struct {
+		name         string
+		sql          string
+		wantName     string
+		concurrently bool
+		withData     *bool
+	}{
+		{
+			name:     "simple REFRESH MATERIALIZED VIEW",
+			sql:      "REFRESH MATERIALIZED VIEW sales_summary",
+			wantName: "sales_summary",
+		},
+		{
+			name:         "REFRESH MATERIALIZED VIEW CONCURRENTLY",
+			sql:          "REFRESH MATERIALIZED VIEW CONCURRENTLY sales_mv",
+			wantName:     "sales_mv",
+			concurrently: true,
+		},
+		{
+			name:     "REFRESH MATERIALIZED VIEW WITH DATA",
+			sql:      "REFRESH MATERIALIZED VIEW mv_test WITH DATA",
+			wantName: "mv_test",
+			withData: boolPtr(true),
+		},
+		{
+			name:     "REFRESH MATERIALIZED VIEW WITH NO DATA",
+			sql:      "REFRESH MATERIALIZED VIEW mv_test WITH NO DATA",
+			wantName: "mv_test",
+			withData: boolPtr(false),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := parseDDLSQL(t, tt.sql)
+			defer ast.ReleaseAST(result)
+
+			if len(result.Statements) != 1 {
+				t.Fatalf("expected 1 statement, got %d", len(result.Statements))
+			}
+
+			stmt, ok := result.Statements[0].(*ast.RefreshMaterializedViewStatement)
+			if !ok {
+				t.Fatalf("expected RefreshMaterializedViewStatement, got %T", result.Statements[0])
+			}
+
+			if stmt.Name != tt.wantName {
+				t.Errorf("expected view name %q, got %q", tt.wantName, stmt.Name)
+			}
+
+			if stmt.Concurrently != tt.concurrently {
+				t.Errorf("expected Concurrently=%v, got %v", tt.concurrently, stmt.Concurrently)
+			}
+
+			if tt.withData != nil {
+				if stmt.WithData == nil {
+					t.Error("expected WithData to be non-nil")
+				} else if *stmt.WithData != *tt.withData {
+					t.Errorf("expected WithData=%v, got %v", *tt.withData, *stmt.WithData)
+				}
+			}
+		})
+	}
+}
+
+func TestParser_DropStatement(t *testing.T) {
+	tests := []struct {
+		name        string
+		sql         string
+		objectType  string
+		wantNames   []string
+		ifExists    bool
+		cascadeType string
+	}{
+		{
+			name:       "DROP TABLE",
+			sql:        "DROP TABLE users",
+			objectType: "TABLE",
+			wantNames:  []string{"users"},
+		},
+		{
+			name:       "DROP TABLE IF EXISTS",
+			sql:        "DROP TABLE IF EXISTS users",
+			objectType: "TABLE",
+			wantNames:  []string{"users"},
+			ifExists:   true,
+		},
+		{
+			name:        "DROP TABLE CASCADE",
+			sql:         "DROP TABLE users CASCADE",
+			objectType:  "TABLE",
+			wantNames:   []string{"users"},
+			cascadeType: "CASCADE",
+		},
+		{
+			name:       "DROP VIEW",
+			sql:        "DROP VIEW user_view",
+			objectType: "VIEW",
+			wantNames:  []string{"user_view"},
+		},
+		{
+			name:       "DROP MATERIALIZED VIEW",
+			sql:        "DROP MATERIALIZED VIEW sales_mv",
+			objectType: "MATERIALIZED VIEW",
+			wantNames:  []string{"sales_mv"},
+		},
+		{
+			name:        "DROP MATERIALIZED VIEW IF EXISTS CASCADE",
+			sql:         "DROP MATERIALIZED VIEW IF EXISTS sales_mv CASCADE",
+			objectType:  "MATERIALIZED VIEW",
+			wantNames:   []string{"sales_mv"},
+			ifExists:    true,
+			cascadeType: "CASCADE",
+		},
+		{
+			name:       "DROP INDEX",
+			sql:        "DROP INDEX idx_users_email",
+			objectType: "INDEX",
+			wantNames:  []string{"idx_users_email"},
+		},
+		{
+			name:       "DROP multiple tables",
+			sql:        "DROP TABLE users, orders, products",
+			objectType: "TABLE",
+			wantNames:  []string{"users", "orders", "products"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := parseDDLSQL(t, tt.sql)
+			defer ast.ReleaseAST(result)
+
+			if len(result.Statements) != 1 {
+				t.Fatalf("expected 1 statement, got %d", len(result.Statements))
+			}
+
+			stmt, ok := result.Statements[0].(*ast.DropStatement)
+			if !ok {
+				t.Fatalf("expected DropStatement, got %T", result.Statements[0])
+			}
+
+			if stmt.ObjectType != tt.objectType {
+				t.Errorf("expected ObjectType %q, got %q", tt.objectType, stmt.ObjectType)
+			}
+
+			if len(stmt.Names) != len(tt.wantNames) {
+				t.Errorf("expected %d names, got %d", len(tt.wantNames), len(stmt.Names))
+			}
+
+			for i, name := range tt.wantNames {
+				if i < len(stmt.Names) && stmt.Names[i] != name {
+					t.Errorf("expected name[%d]=%q, got %q", i, name, stmt.Names[i])
+				}
+			}
+
+			if stmt.IfExists != tt.ifExists {
+				t.Errorf("expected IfExists=%v, got %v", tt.ifExists, stmt.IfExists)
+			}
+
+			if stmt.CascadeType != tt.cascadeType {
+				t.Errorf("expected CascadeType=%q, got %q", tt.cascadeType, stmt.CascadeType)
+			}
+		})
+	}
+}
+
+func TestParser_CreateIndex(t *testing.T) {
+	tests := []struct {
+		name        string
+		sql         string
+		indexName   string
+		tableName   string
+		unique      bool
+		ifNotExists bool
+		numColumns  int
+	}{
+		{
+			name:       "simple CREATE INDEX",
+			sql:        "CREATE INDEX idx_email ON users (email)",
+			indexName:  "idx_email",
+			tableName:  "users",
+			numColumns: 1,
+		},
+		{
+			name:       "CREATE UNIQUE INDEX",
+			sql:        "CREATE UNIQUE INDEX idx_email ON users (email)",
+			indexName:  "idx_email",
+			tableName:  "users",
+			unique:     true,
+			numColumns: 1,
+		},
+		{
+			name:        "CREATE INDEX IF NOT EXISTS",
+			sql:         "CREATE INDEX IF NOT EXISTS idx_name ON users (name)",
+			indexName:   "idx_name",
+			tableName:   "users",
+			ifNotExists: true,
+			numColumns:  1,
+		},
+		{
+			name:       "CREATE INDEX with multiple columns",
+			sql:        "CREATE INDEX idx_composite ON orders (user_id, order_date)",
+			indexName:  "idx_composite",
+			tableName:  "orders",
+			numColumns: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := parseDDLSQL(t, tt.sql)
+			defer ast.ReleaseAST(result)
+
+			if len(result.Statements) != 1 {
+				t.Fatalf("expected 1 statement, got %d", len(result.Statements))
+			}
+
+			stmt, ok := result.Statements[0].(*ast.CreateIndexStatement)
+			if !ok {
+				t.Fatalf("expected CreateIndexStatement, got %T", result.Statements[0])
+			}
+
+			if stmt.Name != tt.indexName {
+				t.Errorf("expected index name %q, got %q", tt.indexName, stmt.Name)
+			}
+
+			if stmt.Table != tt.tableName {
+				t.Errorf("expected table name %q, got %q", tt.tableName, stmt.Table)
+			}
+
+			if stmt.Unique != tt.unique {
+				t.Errorf("expected Unique=%v, got %v", tt.unique, stmt.Unique)
+			}
+
+			if stmt.IfNotExists != tt.ifNotExists {
+				t.Errorf("expected IfNotExists=%v, got %v", tt.ifNotExists, stmt.IfNotExists)
+			}
+
+			if len(stmt.Columns) != tt.numColumns {
+				t.Errorf("expected %d columns, got %d", tt.numColumns, len(stmt.Columns))
+			}
+		})
+	}
+}
+
+func TestParser_CreateTableWithPartitioning(t *testing.T) {
+	tests := []struct {
+		name          string
+		sql           string
+		tableName     string
+		numColumns    int
+		partitionType string
+		numPartitions int
+	}{
+		{
+			name:          "CREATE TABLE with RANGE partitioning",
+			sql:           "CREATE TABLE sales (sale_date DATE, amount DECIMAL) PARTITION BY RANGE (sale_date) (PARTITION p2024 VALUES LESS THAN (MAXVALUE))",
+			tableName:     "sales",
+			numColumns:    2,
+			partitionType: "RANGE",
+			numPartitions: 1,
+		},
+		{
+			name:          "CREATE TABLE with HASH partitioning",
+			sql:           "CREATE TABLE users (id INT, name VARCHAR) PARTITION BY HASH (id)",
+			tableName:     "users",
+			numColumns:    2,
+			partitionType: "HASH",
+			numPartitions: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := parseDDLSQL(t, tt.sql)
+			defer ast.ReleaseAST(result)
+
+			if len(result.Statements) != 1 {
+				t.Fatalf("expected 1 statement, got %d", len(result.Statements))
+			}
+
+			stmt, ok := result.Statements[0].(*ast.CreateTableStatement)
+			if !ok {
+				t.Fatalf("expected CreateTableStatement, got %T", result.Statements[0])
+			}
+
+			if stmt.Name != tt.tableName {
+				t.Errorf("expected table name %q, got %q", tt.tableName, stmt.Name)
+			}
+
+			if len(stmt.Columns) != tt.numColumns {
+				t.Errorf("expected %d columns, got %d", tt.numColumns, len(stmt.Columns))
+			}
+
+			if stmt.PartitionBy == nil {
+				t.Fatal("expected PartitionBy to be non-nil")
+			}
+
+			if stmt.PartitionBy.Type != tt.partitionType {
+				t.Errorf("expected partition type %q, got %q", tt.partitionType, stmt.PartitionBy.Type)
+			}
+
+			if len(stmt.Partitions) != tt.numPartitions {
+				t.Errorf("expected %d partitions, got %d", tt.numPartitions, len(stmt.Partitions))
+			}
+		})
+	}
+}
+
+func TestParser_CreateTableSimple(t *testing.T) {
+	tests := []struct {
+		name        string
+		sql         string
+		tableName   string
+		numColumns  int
+		ifNotExists bool
+		temporary   bool
+	}{
+		{
+			name:       "simple CREATE TABLE",
+			sql:        "CREATE TABLE users (id INT, name VARCHAR)",
+			tableName:  "users",
+			numColumns: 2,
+		},
+		{
+			name:        "CREATE TABLE IF NOT EXISTS",
+			sql:         "CREATE TABLE IF NOT EXISTS users (id INT, name VARCHAR)",
+			tableName:   "users",
+			numColumns:  2,
+			ifNotExists: true,
+		},
+		{
+			name:       "CREATE TEMPORARY TABLE",
+			sql:        "CREATE TEMPORARY TABLE temp_data (id INT, value TEXT)",
+			tableName:  "temp_data",
+			numColumns: 2,
+			temporary:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := parseDDLSQL(t, tt.sql)
+			defer ast.ReleaseAST(result)
+
+			if len(result.Statements) != 1 {
+				t.Fatalf("expected 1 statement, got %d", len(result.Statements))
+			}
+
+			stmt, ok := result.Statements[0].(*ast.CreateTableStatement)
+			if !ok {
+				t.Fatalf("expected CreateTableStatement, got %T", result.Statements[0])
+			}
+
+			if stmt.Name != tt.tableName {
+				t.Errorf("expected table name %q, got %q", tt.tableName, stmt.Name)
+			}
+
+			if len(stmt.Columns) != tt.numColumns {
+				t.Errorf("expected %d columns, got %d", tt.numColumns, len(stmt.Columns))
+			}
+
+			if stmt.IfNotExists != tt.ifNotExists {
+				t.Errorf("expected IfNotExists=%v, got %v", tt.ifNotExists, stmt.IfNotExists)
+			}
+
+			if stmt.Temporary != tt.temporary {
+				t.Errorf("expected Temporary=%v, got %v", tt.temporary, stmt.Temporary)
+			}
+		})
+	}
+}
+
+// Helper function to create bool pointer
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/pkg/sql/parser/parser.go
+++ b/pkg/sql/parser/parser.go
@@ -212,6 +212,15 @@ func (p *Parser) parseStatement() (ast.Statement, error) {
 	case "MERGE":
 		p.advance() // Consume MERGE
 		return p.parseMergeStatement()
+	case "CREATE":
+		p.advance() // Consume CREATE
+		return p.parseCreateStatement()
+	case "DROP":
+		p.advance() // Consume DROP
+		return p.parseDropStatement()
+	case "REFRESH":
+		p.advance() // Consume REFRESH
+		return p.parseRefreshStatement()
 	default:
 		return nil, p.expectedError("statement")
 	}

--- a/pkg/sql/tokenizer/tokenizer.go
+++ b/pkg/sql/tokenizer/tokenizer.go
@@ -93,6 +93,39 @@ var keywordTokenTypes = map[string]models.TokenType{
 	"SOURCE":  models.TokenTypeKeyword,
 	"TARGET":  models.TokenTypeKeyword,
 	// Note: USING is already defined above for JOIN USING
+	// DDL keywords (Phase 4 - Materialized Views & Partitioning)
+	"CREATE":       models.TokenTypeKeyword,
+	"DROP":         models.TokenTypeKeyword,
+	"ALTER":        models.TokenTypeKeyword,
+	"TABLE":        models.TokenTypeKeyword,
+	"INDEX":        models.TokenTypeKeyword,
+	"VIEW":         models.TokenTypeKeyword,
+	"MATERIALIZED": models.TokenTypeKeyword,
+	"REFRESH":      models.TokenTypeKeyword,
+	"CONCURRENTLY": models.TokenTypeKeyword,
+	"CASCADE":      models.TokenTypeKeyword,
+	"RESTRICT":     models.TokenTypeKeyword,
+	"REPLACE":      models.TokenTypeKeyword,
+	"TEMPORARY":    models.TokenTypeKeyword,
+	// Note: TEMP is commonly used as identifier (e.g., CTE name "temp"), not added as keyword
+	"IF":         models.TokenTypeKeyword,
+	"EXISTS":     models.TokenTypeKeyword,
+	"UNIQUE":     models.TokenTypeKeyword,
+	"PRIMARY":    models.TokenTypeKeyword,
+	"KEY":        models.TokenTypeKeyword,
+	"REFERENCES": models.TokenTypeKeyword,
+	"FOREIGN":    models.TokenTypeKeyword,
+	"CHECK":      models.TokenTypeKeyword,
+	"CONSTRAINT": models.TokenTypeKeyword,
+	"TABLESPACE": models.TokenTypeKeyword,
+	// Partitioning keywords
+	"PARTITION": models.TokenTypeKeyword,
+	"RANGE":     models.TokenTypeKeyword,
+	"LIST":      models.TokenTypeKeyword,
+	"HASH":      models.TokenTypeKeyword,
+	"LESS":      models.TokenTypeKeyword,
+	"THAN":      models.TokenTypeKeyword,
+	"MAXVALUE":  models.TokenTypeKeyword,
 }
 
 // Tokenizer provides high-performance SQL tokenization with zero-copy operations


### PR DESCRIPTION
## Summary
- Implements Phase 4 DDL Support: CREATE/DROP/REFRESH MATERIALIZED VIEW, CREATE VIEW, CREATE TABLE with partitioning, CREATE INDEX, DROP statements
- Adds comprehensive AST nodes for views, materialized views, partitions, and drop operations
- Adds 800+ lines of DDL parsing logic with PostgreSQL-style syntax support
- Includes formatter support for new DDL statement types

## Changes

### AST Nodes Added
- `CreateViewStatement` - CREATE [OR REPLACE] [TEMPORARY] VIEW
- `CreateMaterializedViewStatement` - CREATE MATERIALIZED VIEW with WITH [NO] DATA
- `RefreshMaterializedViewStatement` - REFRESH MATERIALIZED VIEW [CONCURRENTLY]
- `DropStatement` - DROP TABLE/VIEW/MATERIALIZED VIEW/INDEX
- `PartitionDefinition` - PARTITION BY RANGE/LIST/HASH definitions

### Parser Changes
- New `ddl.go` with comprehensive DDL parsing
- Added CREATE, DROP, REFRESH to `parseStatement()` switch
- `isTokenMatch()` helper for flexible keyword/identifier matching
- Supports IF EXISTS, IF NOT EXISTS, CASCADE, RESTRICT modifiers

### Tokenizer Updates
- Added DDL keywords: CREATE, DROP, ALTER, TABLE, VIEW, INDEX, MATERIALIZED, REFRESH, etc.
- Added partitioning keywords: PARTITION, RANGE, LIST, HASH, LESS, THAN, MAXVALUE

### Formatter Support
- `formatDrop()` - DROP statement formatting
- `formatCreateView()` - CREATE VIEW formatting
- `formatCreateMaterializedView()` - CREATE MATERIALIZED VIEW formatting
- `formatRefreshMaterializedView()` - REFRESH MATERIALIZED VIEW formatting

## Test plan
- [x] All 30+ DDL test cases pass
- [x] All existing parser tests pass (no regressions)
- [x] All tokenizer tests pass
- [x] All keywords tests pass
- [x] Race detection tests pass
- [x] Pre-commit hooks pass (fmt, vet, tests)

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)