### PR TITLE
feat: implement FETCH FIRST / OFFSET-FETCH clause (SQL-99 F861, F862)

### DIFF
--- a/pkg/models/token_type.go
+++ b/pkg/models/token_type.go
@@ -263,6 +263,8 @@ const (
 	TokenTypeNulls    TokenType = 365
 	TokenTypeFirst    TokenType = 366
 	TokenTypeLast     TokenType = 367
+	TokenTypeFetch    TokenType = 368 // FETCH keyword for FETCH FIRST/NEXT clause
+	TokenTypeNext     TokenType = 369 // NEXT keyword for FETCH NEXT clause
 
 	// MERGE Statement Keywords (370-379)
 	TokenTypeMerge   TokenType = 370
@@ -270,9 +272,11 @@ const (
 	TokenTypeTarget  TokenType = 372
 	TokenTypeSource  TokenType = 373
 
-	// Materialized View Keywords (380-389)
+	// Materialized View Keywords (374-379)
 	TokenTypeMaterialized TokenType = 374
 	TokenTypeRefresh      TokenType = 375
+	TokenTypeTies         TokenType = 376 // TIES keyword for WITH TIES in FETCH clause
+	TokenTypePercent      TokenType = 377 // PERCENT keyword for FETCH ... PERCENT ROWS
 
 	// Grouping Set Keywords (390-399)
 	TokenTypeGroupingSets TokenType = 390
@@ -527,6 +531,8 @@ var tokenStringMap = map[TokenType]string{
 	TokenTypeNulls:    "NULLS",
 	TokenTypeFirst:    "FIRST",
 	TokenTypeLast:     "LAST",
+	TokenTypeFetch:    "FETCH",
+	TokenTypeNext:     "NEXT",
 
 	// MERGE Statement Keywords
 	TokenTypeMerge:   "MERGE",
@@ -537,6 +543,8 @@ var tokenStringMap = map[TokenType]string{
 	// Materialized View Keywords
 	TokenTypeMaterialized: "MATERIALIZED",
 	TokenTypeRefresh:      "REFRESH",
+	TokenTypeTies:         "TIES",
+	TokenTypePercent:      "PERCENT",
 
 	// Grouping Set Keywords
 	TokenTypeGroupingSets: "GROUPING_SETS",

--- a/pkg/sql/keywords/categories.go
+++ b/pkg/sql/keywords/categories.go
@@ -39,21 +39,22 @@ func NewKeywords() *Keywords {
 func (k *Keywords) initialize() {
 	// Initialize DML keywords
 	k.DMLKeywords = map[string]models.TokenType{
-		"DISTINCT": models.TokenTypeKeyword,
-		"ALL":      models.TokenTypeKeyword,
-		"FETCH":    models.TokenTypeKeyword,
-		"NEXT":     models.TokenTypeKeyword,
-		"ROWS":     models.TokenTypeKeyword,
-		"ONLY":     models.TokenTypeKeyword,
-		"WITH":     models.TokenTypeKeyword,
-		"TIES":     models.TokenTypeKeyword,
-		"NULLS":    models.TokenTypeKeyword,
-		"FIRST":    models.TokenTypeKeyword,
-		"LAST":     models.TokenTypeKeyword,
-		"ROLLUP":   models.TokenTypeKeyword, // SQL-99 grouping operation
-		"CUBE":     models.TokenTypeKeyword, // SQL-99 grouping operation
-		"GROUPING": models.TokenTypeKeyword, // SQL-99 GROUPING SETS
-		"SETS":     models.TokenTypeKeyword, // SQL-99 GROUPING SETS
+		"DISTINCT": models.TokenTypeDistinct,
+		"ALL":      models.TokenTypeAll,
+		"FETCH":    models.TokenTypeFetch,
+		"NEXT":     models.TokenTypeNext,
+		"ROWS":     models.TokenTypeRows,
+		"ONLY":     models.TokenTypeOnly,
+		"WITH":     models.TokenTypeWith,
+		"TIES":     models.TokenTypeTies,
+		"NULLS":    models.TokenTypeNulls,
+		"FIRST":    models.TokenTypeFirst,
+		"LAST":     models.TokenTypeLast,
+		"PERCENT":  models.TokenTypePercent,  // SQL-99 FETCH ... PERCENT ROWS
+		"ROLLUP":   models.TokenTypeRollup,   // SQL-99 grouping operation
+		"CUBE":     models.TokenTypeCube,     // SQL-99 grouping operation
+		"GROUPING": models.TokenTypeGrouping, // SQL-99 GROUPING SETS
+		"SETS":     models.TokenTypeSets,     // SQL-99 GROUPING SETS
 	}
 
 	// Initialize compound keywords

--- a/pkg/sql/keywords/keywords.go
+++ b/pkg/sql/keywords/keywords.go
@@ -27,7 +27,7 @@ var RESERVED_FOR_TABLE_ALIAS = []Keyword{
 	{Word: "VIEW", Type: models.TokenTypeKeyword, Reserved: true, ReservedForTableAlias: true},
 	{Word: "LIMIT", Type: models.TokenTypeLimit, Reserved: true, ReservedForTableAlias: true},
 	{Word: "OFFSET", Type: models.TokenTypeOffset, Reserved: true, ReservedForTableAlias: true},
-	{Word: "FETCH", Type: models.TokenTypeKeyword, Reserved: true, ReservedForTableAlias: true},
+	{Word: "FETCH", Type: models.TokenTypeFetch, Reserved: true, ReservedForTableAlias: true},
 	{Word: "UNION", Type: models.TokenTypeKeyword, Reserved: true, ReservedForTableAlias: true},
 	{Word: "EXCEPT", Type: models.TokenTypeKeyword, Reserved: true, ReservedForTableAlias: true},
 	{Word: "INTERSECT", Type: models.TokenTypeKeyword, Reserved: true, ReservedForTableAlias: true},
@@ -78,14 +78,20 @@ var RESERVED_FOR_TABLE_ALIAS = []Keyword{
 	{Word: "MIN", Type: models.TokenTypeMin, Reserved: true, ReservedForTableAlias: true},
 	{Word: "MAX", Type: models.TokenTypeMax, Reserved: true, ReservedForTableAlias: true},
 	// Window function keywords (Phase 2.5)
-	{Word: "OVER", Type: models.TokenTypeKeyword, Reserved: true, ReservedForTableAlias: true},
-	{Word: "ROWS", Type: models.TokenTypeKeyword, Reserved: true, ReservedForTableAlias: true},
-	{Word: "RANGE", Type: models.TokenTypeKeyword, Reserved: true, ReservedForTableAlias: true},
-	{Word: "CURRENT", Type: models.TokenTypeKeyword, Reserved: true, ReservedForTableAlias: true},
-	{Word: "ROW", Type: models.TokenTypeKeyword, Reserved: true, ReservedForTableAlias: true},
-	{Word: "UNBOUNDED", Type: models.TokenTypeKeyword, Reserved: true, ReservedForTableAlias: true},
-	{Word: "PRECEDING", Type: models.TokenTypeKeyword, Reserved: true, ReservedForTableAlias: true},
-	{Word: "FOLLOWING", Type: models.TokenTypeKeyword, Reserved: true, ReservedForTableAlias: true},
+	{Word: "OVER", Type: models.TokenTypeOver, Reserved: true, ReservedForTableAlias: true},
+	{Word: "ROWS", Type: models.TokenTypeRows, Reserved: true, ReservedForTableAlias: true},
+	{Word: "RANGE", Type: models.TokenTypeRange, Reserved: true, ReservedForTableAlias: true},
+	{Word: "CURRENT", Type: models.TokenTypeCurrent, Reserved: true, ReservedForTableAlias: true},
+	{Word: "ROW", Type: models.TokenTypeRow, Reserved: true, ReservedForTableAlias: true},
+	{Word: "UNBOUNDED", Type: models.TokenTypeUnbounded, Reserved: true, ReservedForTableAlias: true},
+	{Word: "PRECEDING", Type: models.TokenTypePreceding, Reserved: true, ReservedForTableAlias: true},
+	{Word: "FOLLOWING", Type: models.TokenTypeFollowing, Reserved: true, ReservedForTableAlias: true},
+	// FETCH clause keywords (SQL-99 F861, F862)
+	{Word: "NEXT", Type: models.TokenTypeNext, Reserved: true, ReservedForTableAlias: true},
+	{Word: "FIRST", Type: models.TokenTypeFirst, Reserved: true, ReservedForTableAlias: true},
+	{Word: "ONLY", Type: models.TokenTypeOnly, Reserved: true, ReservedForTableAlias: true},
+	{Word: "TIES", Type: models.TokenTypeTies, Reserved: true, ReservedForTableAlias: true},
+	{Word: "PERCENT", Type: models.TokenTypePercent, Reserved: true, ReservedForTableAlias: true},
 }
 
 var ADDITIONAL_KEYWORDS = []Keyword{

--- a/pkg/sql/keywords/keywords_test.go
+++ b/pkg/sql/keywords/keywords_test.go
@@ -208,12 +208,12 @@ func TestKeywords_GetKeywordType_Categories(t *testing.T) {
 		word     string
 		expected models.TokenType
 	}{
-		{"DISTINCT", models.TokenTypeKeyword},
-		{"ALL", models.TokenTypeKeyword},
-		{"FETCH", models.TokenTypeKeyword},
-		{"ROWS", models.TokenTypeKeyword},
-		{"distinct", models.TokenTypeKeyword}, // Case insensitive
-		{"all", models.TokenTypeKeyword},
+		{"DISTINCT", models.TokenTypeDistinct},
+		{"ALL", models.TokenTypeAll},
+		{"FETCH", models.TokenTypeFetch},
+		{"ROWS", models.TokenTypeRows},
+		{"distinct", models.TokenTypeDistinct}, // Case insensitive
+		{"all", models.TokenTypeAll},
 		{"NOTAKEYWORD", models.TokenTypeWord}, // Non-existent should return TokenTypeWord
 	}
 
@@ -316,12 +316,12 @@ func TestKeywords_GetDMLKeywordType(t *testing.T) {
 		expectFound  bool
 		expectedType models.TokenType
 	}{
-		{"DISTINCT", true, models.TokenTypeKeyword},
-		{"ALL", true, models.TokenTypeKeyword},
-		{"FETCH", true, models.TokenTypeKeyword},
-		{"NEXT", true, models.TokenTypeKeyword},
-		{"ROWS", true, models.TokenTypeKeyword},
-		{"ONLY", true, models.TokenTypeKeyword},
+		{"DISTINCT", true, models.TokenTypeDistinct},
+		{"ALL", true, models.TokenTypeAll},
+		{"FETCH", true, models.TokenTypeFetch},
+		{"NEXT", true, models.TokenTypeNext},
+		{"ROWS", true, models.TokenTypeRows},
+		{"ONLY", true, models.TokenTypeOnly},
 		{"SELECT", false, 0},
 		{"NOTDML", false, 0},
 	}

--- a/pkg/sql/parser/fetch_test.go
+++ b/pkg/sql/parser/fetch_test.go
@@ -1,0 +1,274 @@
+// Package parser - fetch_test.go
+// Tests for SQL-99 FETCH FIRST/NEXT clause parsing (F861, F862)
+
+package parser
+
+import (
+	"testing"
+
+	"github.com/ajitpratap0/GoSQLX/pkg/sql/ast"
+)
+
+// Note: Uses parseSQL helper from nulls_first_last_test.go
+
+func TestParser_FetchClause(t *testing.T) {
+	tests := []struct {
+		name          string
+		sql           string
+		wantFetchType string
+		wantFetchVal  int64
+		wantWithTies  bool
+		wantIsPercent bool
+		wantOffset    *int
+	}{
+		{
+			name:          "FETCH FIRST 5 ROWS ONLY",
+			sql:           "SELECT * FROM users ORDER BY created_at FETCH FIRST 5 ROWS ONLY",
+			wantFetchType: "FIRST",
+			wantFetchVal:  5,
+			wantWithTies:  false,
+			wantIsPercent: false,
+			wantOffset:    nil,
+		},
+		{
+			name:          "FETCH NEXT 10 ROWS ONLY",
+			sql:           "SELECT * FROM users ORDER BY id FETCH NEXT 10 ROWS ONLY",
+			wantFetchType: "NEXT",
+			wantFetchVal:  10,
+			wantWithTies:  false,
+			wantIsPercent: false,
+			wantOffset:    nil,
+		},
+		{
+			name:          "FETCH FIRST with ROW (singular)",
+			sql:           "SELECT * FROM users FETCH FIRST 1 ROW ONLY",
+			wantFetchType: "FIRST",
+			wantFetchVal:  1,
+			wantWithTies:  false,
+			wantIsPercent: false,
+			wantOffset:    nil,
+		},
+		{
+			name:          "FETCH with WITH TIES",
+			sql:           "SELECT * FROM products ORDER BY price FETCH FIRST 10 ROWS WITH TIES",
+			wantFetchType: "FIRST",
+			wantFetchVal:  10,
+			wantWithTies:  true,
+			wantIsPercent: false,
+			wantOffset:    nil,
+		},
+		{
+			name:          "FETCH with PERCENT",
+			sql:           "SELECT * FROM orders ORDER BY total FETCH FIRST 10 PERCENT ROWS ONLY",
+			wantFetchType: "FIRST",
+			wantFetchVal:  10,
+			wantWithTies:  false,
+			wantIsPercent: true,
+			wantOffset:    nil,
+		},
+		{
+			name:          "FETCH PERCENT WITH TIES",
+			sql:           "SELECT * FROM orders ORDER BY total FETCH FIRST 25 PERCENT ROWS WITH TIES",
+			wantFetchType: "FIRST",
+			wantFetchVal:  25,
+			wantWithTies:  true,
+			wantIsPercent: true,
+			wantOffset:    nil,
+		},
+		{
+			name:          "OFFSET with FETCH",
+			sql:           "SELECT * FROM users ORDER BY id OFFSET 20 FETCH NEXT 10 ROWS ONLY",
+			wantFetchType: "NEXT",
+			wantFetchVal:  10,
+			wantWithTies:  false,
+			wantIsPercent: false,
+			wantOffset:    intPtrFetch(20),
+		},
+		{
+			name:          "OFFSET ROWS with FETCH",
+			sql:           "SELECT * FROM users ORDER BY id OFFSET 20 ROWS FETCH NEXT 10 ROWS ONLY",
+			wantFetchType: "NEXT",
+			wantFetchVal:  10,
+			wantWithTies:  false,
+			wantIsPercent: false,
+			wantOffset:    intPtrFetch(20),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stmt := parseSQL(t, tt.sql)
+
+			if stmt == nil {
+				t.Fatal("expected statement, got nil")
+			}
+
+			if len(stmt.Statements) == 0 {
+				t.Fatal("expected at least one statement")
+			}
+
+			selectStmt, ok := stmt.Statements[0].(*ast.SelectStatement)
+			if !ok {
+				t.Fatalf("expected SelectStatement, got %T", stmt.Statements[0])
+			}
+
+			// Check FETCH clause
+			if selectStmt.Fetch == nil {
+				t.Fatal("expected Fetch clause, got nil")
+			}
+
+			fetch := selectStmt.Fetch
+
+			if fetch.FetchType != tt.wantFetchType {
+				t.Errorf("FetchType = %q, want %q", fetch.FetchType, tt.wantFetchType)
+			}
+
+			if fetch.FetchValue == nil {
+				t.Fatal("expected FetchValue, got nil")
+			}
+
+			if *fetch.FetchValue != tt.wantFetchVal {
+				t.Errorf("FetchValue = %d, want %d", *fetch.FetchValue, tt.wantFetchVal)
+			}
+
+			if fetch.WithTies != tt.wantWithTies {
+				t.Errorf("WithTies = %v, want %v", fetch.WithTies, tt.wantWithTies)
+			}
+
+			if fetch.IsPercent != tt.wantIsPercent {
+				t.Errorf("IsPercent = %v, want %v", fetch.IsPercent, tt.wantIsPercent)
+			}
+
+			// Check OFFSET if expected
+			if tt.wantOffset != nil {
+				if selectStmt.Offset == nil {
+					t.Errorf("expected Offset = %d, got nil", *tt.wantOffset)
+				} else if *selectStmt.Offset != *tt.wantOffset {
+					t.Errorf("Offset = %d, want %d", *selectStmt.Offset, *tt.wantOffset)
+				}
+			}
+		})
+	}
+}
+
+func TestParser_FetchClauseWithComplexQueries(t *testing.T) {
+	tests := []struct {
+		name string
+		sql  string
+	}{
+		{
+			name: "FETCH with WHERE and JOIN",
+			sql: `SELECT u.name, o.total
+				  FROM users u
+				  JOIN orders o ON u.id = o.user_id
+				  WHERE o.status_id = 1
+				  ORDER BY o.total DESC
+				  FETCH FIRST 10 ROWS ONLY`,
+		},
+		{
+			name: "FETCH with GROUP BY and HAVING",
+			sql: `SELECT department, AVG(salary)
+				  FROM employees
+				  GROUP BY department
+				  HAVING COUNT(*) > 5
+				  ORDER BY department DESC
+				  FETCH FIRST 3 ROWS WITH TIES`,
+		},
+		{
+			name: "FETCH with subquery",
+			sql: `SELECT name, salary
+				  FROM employees
+				  WHERE salary > (SELECT AVG(salary) FROM employees)
+				  ORDER BY salary DESC
+				  OFFSET 5 ROWS
+				  FETCH NEXT 10 ROWS ONLY`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stmt := parseSQL(t, tt.sql)
+
+			if stmt == nil || len(stmt.Statements) == 0 {
+				t.Fatal("expected statement")
+			}
+
+			selectStmt, ok := stmt.Statements[0].(*ast.SelectStatement)
+			if !ok {
+				t.Fatalf("expected SelectStatement, got %T", stmt.Statements[0])
+			}
+
+			if selectStmt.Fetch == nil {
+				t.Error("expected Fetch clause")
+			}
+		})
+	}
+}
+
+func TestParser_LimitVsFetch(t *testing.T) {
+	tests := []struct {
+		name      string
+		sql       string
+		wantLimit *int
+		wantFetch bool
+	}{
+		{
+			name:      "MySQL-style LIMIT only",
+			sql:       "SELECT * FROM users LIMIT 10",
+			wantLimit: intPtrFetch(10),
+			wantFetch: false,
+		},
+		{
+			name:      "MySQL-style LIMIT with OFFSET",
+			sql:       "SELECT * FROM users LIMIT 10 OFFSET 5",
+			wantLimit: intPtrFetch(10),
+			wantFetch: false,
+		},
+		{
+			name:      "SQL-99 FETCH only",
+			sql:       "SELECT * FROM users FETCH FIRST 10 ROWS ONLY",
+			wantLimit: nil,
+			wantFetch: true,
+		},
+		{
+			name:      "SQL-99 OFFSET with FETCH",
+			sql:       "SELECT * FROM users OFFSET 5 FETCH NEXT 10 ROWS ONLY",
+			wantLimit: nil,
+			wantFetch: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stmt := parseSQL(t, tt.sql)
+
+			selectStmt, ok := stmt.Statements[0].(*ast.SelectStatement)
+			if !ok {
+				t.Fatalf("expected SelectStatement, got %T", stmt.Statements[0])
+			}
+
+			// Check LIMIT
+			if tt.wantLimit != nil {
+				if selectStmt.Limit == nil {
+					t.Errorf("expected Limit = %d, got nil", *tt.wantLimit)
+				} else if *selectStmt.Limit != *tt.wantLimit {
+					t.Errorf("Limit = %d, want %d", *selectStmt.Limit, *tt.wantLimit)
+				}
+			} else if selectStmt.Limit != nil {
+				t.Errorf("expected Limit = nil, got %d", *selectStmt.Limit)
+			}
+
+			// Check FETCH
+			if tt.wantFetch && selectStmt.Fetch == nil {
+				t.Error("expected Fetch clause, got nil")
+			} else if !tt.wantFetch && selectStmt.Fetch != nil {
+				t.Error("expected no Fetch clause")
+			}
+		})
+	}
+}
+
+// intPtrFetch returns a pointer to an int (named differently to avoid conflict)
+func intPtrFetch(i int) *int {
+	return &i
+}

--- a/pkg/sql/parser/parser.go
+++ b/pkg/sql/parser/parser.go
@@ -432,6 +432,13 @@ var modelTypeToString = map[models.TokenType]token.Type{
 	models.TokenTypeText:    "TEXT",
 	models.TokenTypeBoolean: "BOOLEAN",
 
+	// FETCH clause keywords (SQL-99 F861, F862)
+	models.TokenTypeFetch:   "FETCH",
+	models.TokenTypeNext:    "NEXT",
+	models.TokenTypeTies:    "TIES",
+	models.TokenTypePercent: "PERCENT",
+	models.TokenTypeOnly:    "ONLY",
+
 	// Other keywords
 	models.TokenTypeIf:      "IF",
 	models.TokenTypeRefresh: "REFRESH",

--- a/pkg/sql/parser/window_functions_test.go
+++ b/pkg/sql/parser/window_functions_test.go
@@ -38,7 +38,11 @@ func convertTokensForWindowFunctions(tokens []models.TokenWithSpan) []token.Toke
 				t.Token.Value == "DESC" || t.Token.Value == "ASC" ||
 				t.Token.Value == "BETWEEN" || t.Token.Value == "AND" ||
 				t.Token.Value == "ROW" || t.Token.Value == "NULLS" ||
-				t.Token.Value == "FIRST" || t.Token.Value == "LAST" {
+				t.Token.Value == "FIRST" || t.Token.Value == "LAST" ||
+				// FETCH clause keywords (SQL-99 F861, F862)
+				t.Token.Value == "FETCH" || t.Token.Value == "NEXT" ||
+				t.Token.Value == "ONLY" || t.Token.Value == "TIES" ||
+				t.Token.Value == "PERCENT" || t.Token.Value == "OFFSET" {
 				tokenType = token.Type(t.Token.Value)
 			} else {
 				tokenType = "IDENT"
@@ -62,6 +66,27 @@ func convertTokensForWindowFunctions(tokens []models.TokenWithSpan) []token.Toke
 			tokenType = "AND"
 		case models.TokenTypeBetween:
 			tokenType = "BETWEEN"
+		// FETCH clause token types (SQL-99 F861, F862)
+		case models.TokenTypeFetch:
+			tokenType = "FETCH"
+		case models.TokenTypeNext:
+			tokenType = "NEXT"
+		case models.TokenTypeTies:
+			tokenType = "TIES"
+		case models.TokenTypePercent:
+			tokenType = "PERCENT"
+		case models.TokenTypeOnly:
+			tokenType = "ONLY"
+		case models.TokenTypeOffset:
+			tokenType = "OFFSET"
+		case models.TokenTypeFirst:
+			tokenType = "FIRST"
+		case models.TokenTypeLast:
+			tokenType = "LAST"
+		case models.TokenTypeRows:
+			tokenType = "ROWS"
+		case models.TokenTypeRow:
+			tokenType = "ROW"
 		case models.TokenTypeSum:
 			tokenType = "IDENT" // Treat SUM as identifier for function calls
 		case models.TokenTypeCount:


### PR DESCRIPTION
## Summary
- Implements the SQL-99 FETCH FIRST/NEXT clause (F861, F862) for standard-compliant row limiting
- Adds full support for `FETCH {FIRST | NEXT} n [{ROW | ROWS}] [{PERCENT}] {ONLY | WITH TIES}` syntax
- Enables `OFFSET n {ROW | ROWS}` combined with FETCH clause for pagination

## Key Features
- **FETCH FIRST/NEXT**: Standard SQL row limiting (`FETCH FIRST 10 ROWS ONLY`)
- **WITH TIES**: Preserves ties in sort order when limiting rows
- **PERCENT**: Percentage-based row limiting (`FETCH FIRST 10 PERCENT ROWS ONLY`)
- **OFFSET-FETCH**: SQL-99 pagination (`OFFSET 20 ROWS FETCH NEXT 10 ROWS ONLY`)

## Changes
- Added `FetchClause` AST node with `FetchValue`, `FetchType`, `IsPercent`, `WithTies` fields
- Added token types: `TokenTypeFetch`, `TokenTypeNext`, `TokenTypeTies`, `TokenTypePercent`
- Updated keyword categories with proper token type mappings
- Implemented `parseFetchClause()` parser function
- Added `modelTypeToString` entries for FETCH clause tokens
- Updated token converter for FETCH-related tokens
- Added comprehensive test suite for all FETCH variations

## Test plan
- [x] Added 15+ tests for FETCH clause variations
- [x] All tests pass with race detection (`go test -race ./...`)
- [x] Pre-commit checks pass (fmt, vet, tests)
- [ ] CI/CD pipeline validation

## SQL-99 Standards Compliance
- F861: TOP and FETCH FIRST/NEXT clauses
- F862: OFFSET clause

🤖 Generated with [Claude Code](https://claude.com/claude-code)