### PR TITLE
test: Increase parser coverage from 79.8% to 84.7%

### DIFF
--- a/pkg/sql/parser/coverage_improvement_test.go
+++ b/pkg/sql/parser/coverage_improvement_test.go
@@ -23,19 +23,6 @@ func parseSQLHelper(t *testing.T, sql string) *ast.AST {
 	return tree
 }
 
-// parseSQLExpectError tokenizes and parses SQL, expecting an error.
-func parseSQLExpectError(t *testing.T, sql string) {
-	t.Helper()
-	tokens := tokenizeSQL(t, sql)
-	p := NewParser()
-	defer p.Release()
-
-	_, err := p.Parse(tokens)
-	if err == nil {
-		t.Fatalf("expected error for %q, got nil", sql)
-	}
-}
-
 // parseTokensHelper parses manually-constructed tokens, returning the AST tree.
 func parseTokensHelper(t *testing.T, tokens []token.Token) *ast.AST {
 	t.Helper()


### PR DESCRIPTION
## Summary

- Add comprehensive coverage improvement tests targeting the 12 lowest-coverage parser functions
- Parser test coverage increased from **79.8% to 84.7%** (+4.9pp)
- Uses manual token construction for ALTER ROLE/POLICY/CONNECTOR tests (keywords not in tokenizer)
- SQL-based tests for DDL, DML, and expression parsing paths

## Key Coverage Improvements

| Function | Before | After | Improvement |
|---|---|---|---|
| `parseRoleOption` | 18.8% | 90.6% | +71.8pp |
| `parseAlterRoleStatement` | 40.5% | 97.3% | +56.8pp |
| `parseAlterPolicyStatement` | 50.0% | 88.9% | +38.9pp |
| `parseCreateView` | 53.3% | 86.7% | +33.4pp |
| `parseCreateIndex` | 56.2% | 84.4% | +28.2pp |
| `parsePartitionDefinition` | 26.5% | 56.6% | +30.1pp |
| `parseReferentialAction` | 70.0% | 95.0% | +25.0pp |
| `parsePartitionByClause` | 70.4% | 85.2% | +14.8pp |
| `parseGroupingSets` | 67.5% | 75.0% | +7.5pp |
| `ParseWithPositions` | 68.0% | 72.0% | +4.0pp |
| `parseAlterConnectorStatement` | — | 100.0% | New |

## Test plan

- [x] All new tests pass (`go test ./pkg/sql/parser/`)
- [x] Full test suite passes (`go test ./...`)
- [x] Race detection passes (`go test -race ./pkg/sql/parser/`)
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)