### PR TITLE
perf: Full pipeline benchmark (#222)

### DIFF
--- a/pkg/sql/parser/pipeline_bench_test.go
+++ b/pkg/sql/parser/pipeline_bench_test.go
@@ -59,13 +59,13 @@ func BenchmarkFullPipeline(b *testing.B) {
 // BenchmarkParseError benchmarks error handling performance for invalid SQL.
 func BenchmarkParseError(b *testing.B) {
 	queries := map[string]string{
-		"missing_from":       "SELECT * WHERE x = 1",
-		"missing_table":      "SELECT * FROM",
-		"bad_syntax":         "SELECTT * FROM users",
-		"incomplete_insert":  "INSERT INTO users",
-		"trailing_comma":     "SELECT a, b, FROM t",
-		"unmatched_paren":    "SELECT (a + b FROM t",
-		"empty":              "",
+		"missing_from":      "SELECT * WHERE x = 1",
+		"missing_table":     "SELECT * FROM",
+		"bad_syntax":        "SELECTT * FROM users",
+		"incomplete_insert": "INSERT INTO users",
+		"trailing_comma":    "SELECT a, b, FROM t",
+		"unmatched_paren":   "SELECT (a + b FROM t",
+		"empty":             "",
 	}
 
 	for name, sql := range queries {


### PR DESCRIPTION
Closes #222

- Add `BenchmarkFullPipeline` covering tokenize→convert→parse for 10 query types
- Add `BenchmarkParseError` benchmarking error handling paths  
- Track allocations with `b.ReportAllocs()`
- Covers simple selects, joins, CTEs, window functions, subqueries, DML

Sample results (Apple M4):
```
BenchmarkFullPipeline/simple_select    4.5μs   22KB  54 allocs
BenchmarkFullPipeline/complex         20.4μs   52KB  241 allocs
BenchmarkParseError/empty              2.9μs   19KB  14 allocs
```