### PR TITLE
fix: update schema package to use Assignments (hotfix for broken main)

### DIFF
--- a/pkg/schema/constraints.go
+++ b/pkg/schema/constraints.go
@@ -145,7 +145,7 @@ func (v *Validator) validateUpdateNotNull(s *ast.UpdateStatement) []ValidationEr
 		}
 	}
 
-	for _, upd := range s.Updates {
+	for _, upd := range s.Assignments {
 		checkAssignment(upd.Column, upd.Value)
 	}
 	for _, upd := range s.Assignments {

--- a/pkg/schema/validator.go
+++ b/pkg/schema/validator.go
@@ -264,7 +264,7 @@ func (v *Validator) validateUpdate(s *ast.UpdateStatement) []ValidationError {
 	}
 
 	// Validate SET column names (using Updates field)
-	for _, upd := range s.Updates {
+	for _, upd := range s.Assignments {
 		colName := extractColumnName(upd.Column)
 		if colName == "" {
 			continue


### PR DESCRIPTION
Main is broken after merging #229 — `pkg/schema/` still references the removed `Updates` field. This replaces `s.Updates` with `s.Assignments` in two files.