### PR TITLE
refactor(#215): Phase 2C — Migrate test files to models.TokenType

### DIFF
--- a/pkg/sql/parser/aggregate_orderby_test.go
+++ b/pkg/sql/parser/aggregate_orderby_test.go
@@ -19,8 +19,8 @@ func convertTokensForAggregateTests(tokens []models.TokenWithSpan) []token.Token
 	for _, t := range tokens {
 		// Handle compound keywords by splitting them
 		if t.Token.Value == "ORDER BY" || t.Token.Type == models.TokenTypeOrderBy {
-			result = append(result, token.Token{Type: "ORDER", Literal: "ORDER"})
-			result = append(result, token.Token{Type: "BY", Literal: "BY"})
+			result = append(result, token.Token{Type: "ORDER", ModelType: models.TokenTypeOrder, Literal: "ORDER"})
+			result = append(result, token.Token{Type: "BY", ModelType: models.TokenTypeBy, Literal: "BY"})
 			continue
 		}
 

--- a/pkg/sql/parser/between_complex_test.go
+++ b/pkg/sql/parser/between_complex_test.go
@@ -4,6 +4,7 @@
 package parser
 
 import (
+	"github.com/ajitpratap0/GoSQLX/pkg/models"
 	"testing"
 
 	"github.com/ajitpratap0/GoSQLX/pkg/sql/ast"
@@ -14,7 +15,8 @@ import (
 // Example: SELECT * FROM orders WHERE created_at BETWEEN NOW() - INTERVAL '30 days' AND NOW()
 func TestParser_BetweenWithIntervalArithmetic(t *testing.T) {
 	tokens := []token.Token{
-		{Type: "SELECT", Literal: "SELECT"},
+		{Type: "SELECT",
+			ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 		{Type: "*", Literal: "*"},
 		{Type: "FROM", Literal: "FROM"},
 		{Type: "IDENT", Literal: "orders"},
@@ -98,7 +100,8 @@ func TestParser_BetweenWithIntervalArithmetic(t *testing.T) {
 // Example: SELECT * FROM data WHERE value BETWEEN (SELECT min_val FROM limits) AND (SELECT max_val FROM limits)
 func TestParser_BetweenWithSubqueries(t *testing.T) {
 	tokens := []token.Token{
-		{Type: "SELECT", Literal: "SELECT"},
+		{Type: "SELECT",
+			ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 		{Type: "*", Literal: "*"},
 		{Type: "FROM", Literal: "FROM"},
 		{Type: "IDENT", Literal: "data"},
@@ -177,7 +180,8 @@ func TestParser_BetweenWithSubqueries(t *testing.T) {
 // Example: SELECT * FROM sales WHERE amount BETWEEN (price * 0.8) + discount AND (price * 1.2) - fee
 func TestParser_BetweenWithMixedComplexExpressions(t *testing.T) {
 	tokens := []token.Token{
-		{Type: "SELECT", Literal: "SELECT"},
+		{Type: "SELECT",
+			ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 		{Type: "*", Literal: "*"},
 		{Type: "FROM", Literal: "FROM"},
 		{Type: "IDENT", Literal: "sales"},
@@ -248,7 +252,8 @@ func TestParser_BetweenWithMixedComplexExpressions(t *testing.T) {
 // Example: SELECT * FROM metrics WHERE score BETWEEN ROUND(AVG(baseline)) AND CEIL(MAX(threshold))
 func TestParser_BetweenWithNestedFunctionCalls(t *testing.T) {
 	tokens := []token.Token{
-		{Type: "SELECT", Literal: "SELECT"},
+		{Type: "SELECT",
+			ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 		{Type: "*", Literal: "*"},
 		{Type: "FROM", Literal: "FROM"},
 		{Type: "IDENT", Literal: "metrics"},
@@ -331,7 +336,8 @@ func TestParser_BetweenWithNestedFunctionCalls(t *testing.T) {
 // Example: SELECT * FROM products WHERE price BETWEEN CAST(min_price AS DECIMAL) AND CAST(max_price AS DECIMAL)
 func TestParser_BetweenWithCastExpressions(t *testing.T) {
 	tokens := []token.Token{
-		{Type: "SELECT", Literal: "SELECT"},
+		{Type: "SELECT",
+			ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 		{Type: "*", Literal: "*"},
 		{Type: "FROM", Literal: "FROM"},
 		{Type: "IDENT", Literal: "products"},
@@ -391,7 +397,8 @@ func TestParser_BetweenWithCastExpressions(t *testing.T) {
 // Example: SELECT * FROM orders WHERE total BETWEEN CASE WHEN discount THEN 100 ELSE 200 END AND 1000
 func TestParser_BetweenWithCaseExpressions(t *testing.T) {
 	tokens := []token.Token{
-		{Type: "SELECT", Literal: "SELECT"},
+		{Type: "SELECT",
+			ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 		{Type: "*", Literal: "*"},
 		{Type: "FROM", Literal: "FROM"},
 		{Type: "IDENT", Literal: "orders"},
@@ -448,7 +455,8 @@ func TestParser_BetweenWithCaseExpressions(t *testing.T) {
 // Example: SELECT * FROM products WHERE price NOT BETWEEN price * 0.5 AND price * 2
 func TestParser_NotBetweenWithComplexExpressions(t *testing.T) {
 	tokens := []token.Token{
-		{Type: "SELECT", Literal: "SELECT"},
+		{Type: "SELECT",
+			ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 		{Type: "*", Literal: "*"},
 		{Type: "FROM", Literal: "FROM"},
 		{Type: "IDENT", Literal: "products"},
@@ -508,7 +516,8 @@ func TestParser_NotBetweenWithComplexExpressions(t *testing.T) {
 // Example: SELECT * FROM users WHERE full_name BETWEEN first_name || ' A' AND first_name || ' Z'
 func TestParser_BetweenWithStringConcatenation(t *testing.T) {
 	tokens := []token.Token{
-		{Type: "SELECT", Literal: "SELECT"},
+		{Type: "SELECT",
+			ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 		{Type: "*", Literal: "*"},
 		{Type: "FROM", Literal: "FROM"},
 		{Type: "IDENT", Literal: "users"},

--- a/pkg/sql/parser/cast_test.go
+++ b/pkg/sql/parser/cast_test.go
@@ -4,6 +4,7 @@
 package parser
 
 import (
+	"github.com/ajitpratap0/GoSQLX/pkg/models"
 	"testing"
 
 	"github.com/ajitpratap0/GoSQLX/pkg/sql/ast"
@@ -14,7 +15,8 @@ import (
 func TestParser_CastExpression_Simple(t *testing.T) {
 	// SELECT CAST(id AS VARCHAR) FROM users
 	tokens := []token.Token{
-		{Type: "SELECT", Literal: "SELECT"},
+		{Type: "SELECT",
+			ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 		{Type: "CAST", Literal: "CAST"},
 		{Type: "(", Literal: "("},
 		{Type: "IDENT", Literal: "id"},
@@ -66,7 +68,8 @@ func TestParser_CastExpression_Simple(t *testing.T) {
 func TestParser_CastExpression_WithPrecision(t *testing.T) {
 	// SELECT CAST(price AS DECIMAL(10,2)) FROM products
 	tokens := []token.Token{
-		{Type: "SELECT", Literal: "SELECT"},
+		{Type: "SELECT",
+			ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 		{Type: "CAST", Literal: "CAST"},
 		{Type: "(", Literal: "("},
 		{Type: "IDENT", Literal: "price"},
@@ -103,7 +106,8 @@ func TestParser_CastExpression_WithPrecision(t *testing.T) {
 func TestParser_CastExpression_VarcharWithLength(t *testing.T) {
 	// SELECT CAST(name AS VARCHAR(100)) FROM users
 	tokens := []token.Token{
-		{Type: "SELECT", Literal: "SELECT"},
+		{Type: "SELECT",
+			ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 		{Type: "CAST", Literal: "CAST"},
 		{Type: "(", Literal: "("},
 		{Type: "IDENT", Literal: "name"},
@@ -138,7 +142,8 @@ func TestParser_CastExpression_VarcharWithLength(t *testing.T) {
 func TestParser_CastExpression_MultipleCasts(t *testing.T) {
 	// SELECT CAST(id AS VARCHAR), CAST(price AS DECIMAL) FROM products
 	tokens := []token.Token{
-		{Type: "SELECT", Literal: "SELECT"},
+		{Type: "SELECT",
+			ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 		{Type: "CAST", Literal: "CAST"},
 		{Type: "(", Literal: "("},
 		{Type: "IDENT", Literal: "id"},
@@ -194,7 +199,8 @@ func TestParser_CastExpression_MultipleCasts(t *testing.T) {
 func TestParser_CastExpression_WithArithmetic(t *testing.T) {
 	// SELECT CAST(price * 1.1 AS DECIMAL) FROM products
 	tokens := []token.Token{
-		{Type: "SELECT", Literal: "SELECT"},
+		{Type: "SELECT",
+			ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 		{Type: "CAST", Literal: "CAST"},
 		{Type: "(", Literal: "("},
 		{Type: "IDENT", Literal: "price"},
@@ -229,7 +235,8 @@ func TestParser_CastExpression_WithArithmetic(t *testing.T) {
 func TestParser_CastExpression_InWhereClause(t *testing.T) {
 	// SELECT * FROM users WHERE CAST(id AS INT) = 1
 	tokens := []token.Token{
-		{Type: "SELECT", Literal: "SELECT"},
+		{Type: "SELECT",
+			ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 		{Type: "*", Literal: "*"},
 		{Type: "FROM", Literal: "FROM"},
 		{Type: "IDENT", Literal: "users"},
@@ -275,7 +282,8 @@ func TestParser_CastExpression_InWhereClause(t *testing.T) {
 func TestParser_CastExpression_Nested(t *testing.T) {
 	// SELECT CAST(CAST(id AS VARCHAR) AS TEXT) FROM users
 	tokens := []token.Token{
-		{Type: "SELECT", Literal: "SELECT"},
+		{Type: "SELECT",
+			ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 		{Type: "CAST", Literal: "CAST"},
 		{Type: "(", Literal: "("},
 		{Type: "CAST", Literal: "CAST"},

--- a/pkg/sql/parser/comprehensive_bench_test.go
+++ b/pkg/sql/parser/comprehensive_bench_test.go
@@ -2,6 +2,7 @@ package parser
 
 import (
 	"fmt"
+	"github.com/ajitpratap0/GoSQLX/pkg/models"
 	"runtime"
 	"sync"
 	"testing"
@@ -13,19 +14,21 @@ import (
 // Generate complex token sets for comprehensive testing
 func generateLargeSelectTokens(numColumns int) []token.Token {
 	tokens := []token.Token{
-		{Type: "SELECT", Literal: "SELECT"},
+		{Type: "SELECT",
+			ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 	}
 
 	// Add multiple columns
 	for i := 0; i < numColumns; i++ {
 		if i > 0 {
-			tokens = append(tokens, token.Token{Type: ",", Literal: ","})
+			tokens = append(tokens, token.Token{Type: ",", ModelType: models.TokenTypeComma, Literal: ","})
 		}
-		tokens = append(tokens, token.Token{Type: "IDENT", Literal: fmt.Sprintf("col%d", i)})
+		tokens = append(tokens, token.Token{Type: "IDENT", ModelType: models.TokenTypeIdentifier, Literal: fmt.Sprintf("col%d", i)})
 	}
 
 	tokens = append(tokens, []token.Token{
-		{Type: "FROM", Literal: "FROM"},
+		{Type: "FROM",
+			ModelType: models.TokenTypeFrom, Literal: "FROM"},
 		{Type: "IDENT", Literal: "large_table"},
 		{Type: "WHERE", Literal: "WHERE"},
 		{Type: "IDENT", Literal: "active"},
@@ -39,7 +42,8 @@ func generateLargeSelectTokens(numColumns int) []token.Token {
 
 func generateComplexJoinTokens(numJoins int) []token.Token {
 	tokens := []token.Token{
-		{Type: "SELECT", Literal: "SELECT"},
+		{Type: "SELECT",
+			ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 		{Type: "IDENT", Literal: "t1"},
 		{Type: ".", Literal: "."},
 		{Type: "IDENT", Literal: "id"},
@@ -48,7 +52,8 @@ func generateComplexJoinTokens(numJoins int) []token.Token {
 	// Add columns from joined tables
 	for i := 0; i < numJoins; i++ {
 		colTokens := []token.Token{
-			{Type: ",", Literal: ","},
+			{Type: ",",
+				ModelType: models.TokenTypeComma, Literal: ","},
 			{Type: "IDENT", Literal: fmt.Sprintf("t%d", i+2)},
 			{Type: ".", Literal: "."},
 			{Type: "IDENT", Literal: "name"},
@@ -58,7 +63,8 @@ func generateComplexJoinTokens(numJoins int) []token.Token {
 
 	// Add FROM clause
 	tokens = append(tokens, []token.Token{
-		{Type: "FROM", Literal: "FROM"},
+		{Type: "FROM",
+			ModelType: models.TokenTypeFrom, Literal: "FROM"},
 		{Type: "IDENT", Literal: "table1"},
 		{Type: "IDENT", Literal: "t1"},
 	}...)
@@ -66,7 +72,8 @@ func generateComplexJoinTokens(numJoins int) []token.Token {
 	// Add multiple joins
 	for i := 0; i < numJoins; i++ {
 		joinTokens := []token.Token{
-			{Type: "JOIN", Literal: "JOIN"},
+			{Type: "JOIN",
+				ModelType: models.TokenTypeJoin, Literal: "JOIN"},
 			{Type: "IDENT", Literal: fmt.Sprintf("table%d", i+2)},
 			{Type: "IDENT", Literal: fmt.Sprintf("t%d", i+2)},
 			{Type: "ON", Literal: "ON"},
@@ -82,7 +89,7 @@ func generateComplexJoinTokens(numJoins int) []token.Token {
 	}
 
 	// Add EOF token
-	tokens = append(tokens, token.Token{Type: "EOF", Literal: ""})
+	tokens = append(tokens, token.Token{Type: "EOF", ModelType: models.TokenTypeEOF, Literal: ""})
 
 	return tokens
 }
@@ -108,7 +115,8 @@ func BenchmarkParserComplexity(b *testing.B) {
 	b.Run("SingleJoin", func(b *testing.B) {
 		// Use existing complex SELECT tokens which include JOIN
 		tokens := []token.Token{
-			{Type: "SELECT", Literal: "SELECT"},
+			{Type: "SELECT",
+				ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 			{Type: "IDENT", Literal: "u"},
 			{Type: ".", Literal: "."},
 			{Type: "IDENT", Literal: "id"},
@@ -137,7 +145,8 @@ func BenchmarkParserComplexity(b *testing.B) {
 
 	b.Run("SimpleWhere", func(b *testing.B) {
 		tokens := []token.Token{
-			{Type: "SELECT", Literal: "SELECT"},
+			{Type: "SELECT",
+				ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 			{Type: "IDENT", Literal: "id"},
 			{Type: "FROM", Literal: "FROM"},
 			{Type: "IDENT", Literal: "users"},
@@ -329,7 +338,8 @@ func BenchmarkParserStatementTypes(b *testing.B) {
 		{
 			name: "INSERT_Simple",
 			tokens: []token.Token{
-				{Type: "INSERT", Literal: "INSERT"},
+				{Type: "INSERT",
+					ModelType: models.TokenTypeInsert, Literal: "INSERT"},
 				{Type: "INTO", Literal: "INTO"},
 				{Type: "IDENT", Literal: "users"},
 				{Type: "(", Literal: "("},
@@ -345,7 +355,8 @@ func BenchmarkParserStatementTypes(b *testing.B) {
 		{
 			name: "UPDATE_Simple",
 			tokens: []token.Token{
-				{Type: "UPDATE", Literal: "UPDATE"},
+				{Type: "UPDATE",
+					ModelType: models.TokenTypeUpdate, Literal: "UPDATE"},
 				{Type: "IDENT", Literal: "users"},
 				{Type: "SET", Literal: "SET"},
 				{Type: "IDENT", Literal: "active"},
@@ -361,7 +372,8 @@ func BenchmarkParserStatementTypes(b *testing.B) {
 		{
 			name: "DELETE_Simple",
 			tokens: []token.Token{
-				{Type: "DELETE", Literal: "DELETE"},
+				{Type: "DELETE",
+					ModelType: models.TokenTypeDelete, Literal: "DELETE"},
 				{Type: "FROM", Literal: "FROM"},
 				{Type: "IDENT", Literal: "users"},
 				{Type: "WHERE", Literal: "WHERE"},
@@ -390,7 +402,8 @@ func BenchmarkParserMixedWorkload(b *testing.B) {
 		generateLargeSelectTokens(5),
 		generateLargeSelectTokens(20),
 		{
-			{Type: "INSERT", Literal: "INSERT"},
+			{Type: "INSERT",
+				ModelType: models.TokenTypeInsert, Literal: "INSERT"},
 			{Type: "INTO", Literal: "INTO"},
 			{Type: "IDENT", Literal: "users"},
 			{Type: "(", Literal: "("},

--- a/pkg/sql/parser/coverage_improvement_test.go
+++ b/pkg/sql/parser/coverage_improvement_test.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"github.com/ajitpratap0/GoSQLX/pkg/models"
 	"strings"
 	"testing"
 
@@ -168,7 +169,8 @@ func TestParsePartitionDefinition(t *testing.T) {
 func TestParseAlterRole(t *testing.T) {
 	t.Run("RENAME TO", func(t *testing.T) {
 		tokens := []token.Token{
-			{Type: "ALTER", Literal: "ALTER"},
+			{Type: "ALTER",
+				ModelType: models.TokenTypeAlter, Literal: "ALTER"},
 			{Type: "ROLE", Literal: "ROLE"},
 			{Type: "IDENT", Literal: "admin"},
 			{Type: "RENAME", Literal: "RENAME"},
@@ -199,7 +201,8 @@ func TestParseAlterRole(t *testing.T) {
 
 	t.Run("ADD MEMBER", func(t *testing.T) {
 		tokens := []token.Token{
-			{Type: "ALTER", Literal: "ALTER"},
+			{Type: "ALTER",
+				ModelType: models.TokenTypeAlter, Literal: "ALTER"},
 			{Type: "ROLE", Literal: "ROLE"},
 			{Type: "IDENT", Literal: "admins"},
 			{Type: "ADD", Literal: "ADD"},
@@ -221,7 +224,8 @@ func TestParseAlterRole(t *testing.T) {
 
 	t.Run("DROP MEMBER", func(t *testing.T) {
 		tokens := []token.Token{
-			{Type: "ALTER", Literal: "ALTER"},
+			{Type: "ALTER",
+				ModelType: models.TokenTypeAlter, Literal: "ALTER"},
 			{Type: "ROLE", Literal: "ROLE"},
 			{Type: "IDENT", Literal: "admins"},
 			{Type: "DROP", Literal: "DROP"},
@@ -240,7 +244,8 @@ func TestParseAlterRole(t *testing.T) {
 
 	t.Run("SET config TO", func(t *testing.T) {
 		tokens := []token.Token{
-			{Type: "ALTER", Literal: "ALTER"},
+			{Type: "ALTER",
+				ModelType: models.TokenTypeAlter, Literal: "ALTER"},
 			{Type: "ROLE", Literal: "ROLE"},
 			{Type: "IDENT", Literal: "admin"},
 			{Type: "SET", Literal: "SET"},
@@ -263,7 +268,8 @@ func TestParseAlterRole(t *testing.T) {
 
 	t.Run("SET config equals", func(t *testing.T) {
 		tokens := []token.Token{
-			{Type: "ALTER", Literal: "ALTER"},
+			{Type: "ALTER",
+				ModelType: models.TokenTypeAlter, Literal: "ALTER"},
 			{Type: "ROLE", Literal: "ROLE"},
 			{Type: "IDENT", Literal: "admin"},
 			{Type: "SET", Literal: "SET"},
@@ -283,7 +289,8 @@ func TestParseAlterRole(t *testing.T) {
 
 	t.Run("RESET config", func(t *testing.T) {
 		tokens := []token.Token{
-			{Type: "ALTER", Literal: "ALTER"},
+			{Type: "ALTER",
+				ModelType: models.TokenTypeAlter, Literal: "ALTER"},
 			{Type: "ROLE", Literal: "ROLE"},
 			{Type: "IDENT", Literal: "admin"},
 			{Type: "RESET", Literal: "RESET"},
@@ -304,7 +311,8 @@ func TestParseAlterRole(t *testing.T) {
 
 	t.Run("RESET ALL", func(t *testing.T) {
 		tokens := []token.Token{
-			{Type: "ALTER", Literal: "ALTER"},
+			{Type: "ALTER",
+				ModelType: models.TokenTypeAlter, Literal: "ALTER"},
 			{Type: "ROLE", Literal: "ROLE"},
 			{Type: "IDENT", Literal: "admin"},
 			{Type: "RESET", Literal: "RESET"},
@@ -322,7 +330,8 @@ func TestParseAlterRole(t *testing.T) {
 
 	t.Run("WITH SUPERUSER", func(t *testing.T) {
 		tokens := []token.Token{
-			{Type: "ALTER", Literal: "ALTER"},
+			{Type: "ALTER",
+				ModelType: models.TokenTypeAlter, Literal: "ALTER"},
 			{Type: "ROLE", Literal: "ROLE"},
 			{Type: "IDENT", Literal: "admin"},
 			{Type: "WITH", Literal: "WITH"},
@@ -343,7 +352,8 @@ func TestParseAlterRole(t *testing.T) {
 
 	t.Run("WITH NOSUPERUSER", func(t *testing.T) {
 		tokens := []token.Token{
-			{Type: "ALTER", Literal: "ALTER"},
+			{Type: "ALTER",
+				ModelType: models.TokenTypeAlter, Literal: "ALTER"},
 			{Type: "ROLE", Literal: "ROLE"},
 			{Type: "IDENT", Literal: "admin"},
 			{Type: "WITH", Literal: "WITH"},
@@ -355,7 +365,8 @@ func TestParseAlterRole(t *testing.T) {
 
 	t.Run("WITH CREATEDB", func(t *testing.T) {
 		tokens := []token.Token{
-			{Type: "ALTER", Literal: "ALTER"},
+			{Type: "ALTER",
+				ModelType: models.TokenTypeAlter, Literal: "ALTER"},
 			{Type: "ROLE", Literal: "ROLE"},
 			{Type: "IDENT", Literal: "admin"},
 			{Type: "WITH", Literal: "WITH"},
@@ -367,7 +378,8 @@ func TestParseAlterRole(t *testing.T) {
 
 	t.Run("WITH NOCREATEDB", func(t *testing.T) {
 		tokens := []token.Token{
-			{Type: "ALTER", Literal: "ALTER"},
+			{Type: "ALTER",
+				ModelType: models.TokenTypeAlter, Literal: "ALTER"},
 			{Type: "ROLE", Literal: "ROLE"},
 			{Type: "IDENT", Literal: "admin"},
 			{Type: "WITH", Literal: "WITH"},
@@ -379,7 +391,8 @@ func TestParseAlterRole(t *testing.T) {
 
 	t.Run("WITH CREATEROLE", func(t *testing.T) {
 		tokens := []token.Token{
-			{Type: "ALTER", Literal: "ALTER"},
+			{Type: "ALTER",
+				ModelType: models.TokenTypeAlter, Literal: "ALTER"},
 			{Type: "ROLE", Literal: "ROLE"},
 			{Type: "IDENT", Literal: "admin"},
 			{Type: "WITH", Literal: "WITH"},
@@ -391,7 +404,8 @@ func TestParseAlterRole(t *testing.T) {
 
 	t.Run("WITH NOCREATEROLE", func(t *testing.T) {
 		tokens := []token.Token{
-			{Type: "ALTER", Literal: "ALTER"},
+			{Type: "ALTER",
+				ModelType: models.TokenTypeAlter, Literal: "ALTER"},
 			{Type: "ROLE", Literal: "ROLE"},
 			{Type: "IDENT", Literal: "admin"},
 			{Type: "WITH", Literal: "WITH"},
@@ -403,7 +417,8 @@ func TestParseAlterRole(t *testing.T) {
 
 	t.Run("WITH LOGIN", func(t *testing.T) {
 		tokens := []token.Token{
-			{Type: "ALTER", Literal: "ALTER"},
+			{Type: "ALTER",
+				ModelType: models.TokenTypeAlter, Literal: "ALTER"},
 			{Type: "ROLE", Literal: "ROLE"},
 			{Type: "IDENT", Literal: "admin"},
 			{Type: "WITH", Literal: "WITH"},
@@ -415,7 +430,8 @@ func TestParseAlterRole(t *testing.T) {
 
 	t.Run("WITH NOLOGIN", func(t *testing.T) {
 		tokens := []token.Token{
-			{Type: "ALTER", Literal: "ALTER"},
+			{Type: "ALTER",
+				ModelType: models.TokenTypeAlter, Literal: "ALTER"},
 			{Type: "ROLE", Literal: "ROLE"},
 			{Type: "IDENT", Literal: "admin"},
 			{Type: "WITH", Literal: "WITH"},
@@ -427,7 +443,8 @@ func TestParseAlterRole(t *testing.T) {
 
 	t.Run("WITH PASSWORD", func(t *testing.T) {
 		tokens := []token.Token{
-			{Type: "ALTER", Literal: "ALTER"},
+			{Type: "ALTER",
+				ModelType: models.TokenTypeAlter, Literal: "ALTER"},
 			{Type: "ROLE", Literal: "ROLE"},
 			{Type: "IDENT", Literal: "admin"},
 			{Type: "WITH", Literal: "WITH"},
@@ -440,7 +457,8 @@ func TestParseAlterRole(t *testing.T) {
 
 	t.Run("WITH PASSWORD NULL", func(t *testing.T) {
 		tokens := []token.Token{
-			{Type: "ALTER", Literal: "ALTER"},
+			{Type: "ALTER",
+				ModelType: models.TokenTypeAlter, Literal: "ALTER"},
 			{Type: "ROLE", Literal: "ROLE"},
 			{Type: "IDENT", Literal: "admin"},
 			{Type: "WITH", Literal: "WITH"},
@@ -453,7 +471,8 @@ func TestParseAlterRole(t *testing.T) {
 
 	t.Run("WITH VALID UNTIL", func(t *testing.T) {
 		tokens := []token.Token{
-			{Type: "ALTER", Literal: "ALTER"},
+			{Type: "ALTER",
+				ModelType: models.TokenTypeAlter, Literal: "ALTER"},
 			{Type: "ROLE", Literal: "ROLE"},
 			{Type: "IDENT", Literal: "admin"},
 			{Type: "WITH", Literal: "WITH"},
@@ -471,7 +490,8 @@ func TestParseAlterRole(t *testing.T) {
 func TestParseAlterPolicy(t *testing.T) {
 	t.Run("RENAME TO", func(t *testing.T) {
 		tokens := []token.Token{
-			{Type: "ALTER", Literal: "ALTER"},
+			{Type: "ALTER",
+				ModelType: models.TokenTypeAlter, Literal: "ALTER"},
 			{Type: "POLICY", Literal: "POLICY"},
 			{Type: "IDENT", Literal: "user_policy"},
 			{Type: "ON", Literal: "ON"},
@@ -495,7 +515,8 @@ func TestParseAlterPolicy(t *testing.T) {
 
 	t.Run("with TO roles", func(t *testing.T) {
 		tokens := []token.Token{
-			{Type: "ALTER", Literal: "ALTER"},
+			{Type: "ALTER",
+				ModelType: models.TokenTypeAlter, Literal: "ALTER"},
 			{Type: "POLICY", Literal: "POLICY"},
 			{Type: "IDENT", Literal: "user_policy"},
 			{Type: "ON", Literal: "ON"},
@@ -520,7 +541,8 @@ func TestParseAlterPolicy(t *testing.T) {
 
 	t.Run("with USING", func(t *testing.T) {
 		tokens := []token.Token{
-			{Type: "ALTER", Literal: "ALTER"},
+			{Type: "ALTER",
+				ModelType: models.TokenTypeAlter, Literal: "ALTER"},
 			{Type: "POLICY", Literal: "POLICY"},
 			{Type: "IDENT", Literal: "user_policy"},
 			{Type: "ON", Literal: "ON"},
@@ -544,7 +566,8 @@ func TestParseAlterPolicy(t *testing.T) {
 
 	t.Run("with WITH CHECK", func(t *testing.T) {
 		tokens := []token.Token{
-			{Type: "ALTER", Literal: "ALTER"},
+			{Type: "ALTER",
+				ModelType: models.TokenTypeAlter, Literal: "ALTER"},
 			{Type: "POLICY", Literal: "POLICY"},
 			{Type: "IDENT", Literal: "user_policy"},
 			{Type: "ON", Literal: "ON"},
@@ -569,7 +592,8 @@ func TestParseAlterPolicy(t *testing.T) {
 
 	t.Run("with TO and USING", func(t *testing.T) {
 		tokens := []token.Token{
-			{Type: "ALTER", Literal: "ALTER"},
+			{Type: "ALTER",
+				ModelType: models.TokenTypeAlter, Literal: "ALTER"},
 			{Type: "POLICY", Literal: "POLICY"},
 			{Type: "IDENT", Literal: "user_policy"},
 			{Type: "ON", Literal: "ON"},
@@ -1074,7 +1098,8 @@ func TestParseReturningClauseCoverage(t *testing.T) {
 func TestParseAlterConnectorCoverage(t *testing.T) {
 	t.Run("SET DCPROPERTIES", func(t *testing.T) {
 		tokens := []token.Token{
-			{Type: "ALTER", Literal: "ALTER"},
+			{Type: "ALTER",
+				ModelType: models.TokenTypeAlter, Literal: "ALTER"},
 			{Type: "CONNECTOR", Literal: "CONNECTOR"},
 			{Type: "IDENT", Literal: "my_connector"},
 			{Type: "SET", Literal: "SET"},
@@ -1095,7 +1120,8 @@ func TestParseAlterConnectorCoverage(t *testing.T) {
 
 	t.Run("SET URL", func(t *testing.T) {
 		tokens := []token.Token{
-			{Type: "ALTER", Literal: "ALTER"},
+			{Type: "ALTER",
+				ModelType: models.TokenTypeAlter, Literal: "ALTER"},
 			{Type: "CONNECTOR", Literal: "CONNECTOR"},
 			{Type: "IDENT", Literal: "my_connector"},
 			{Type: "SET", Literal: "SET"},
@@ -1108,7 +1134,8 @@ func TestParseAlterConnectorCoverage(t *testing.T) {
 
 	t.Run("SET OWNER USER", func(t *testing.T) {
 		tokens := []token.Token{
-			{Type: "ALTER", Literal: "ALTER"},
+			{Type: "ALTER",
+				ModelType: models.TokenTypeAlter, Literal: "ALTER"},
 			{Type: "CONNECTOR", Literal: "CONNECTOR"},
 			{Type: "IDENT", Literal: "my_connector"},
 			{Type: "SET", Literal: "SET"},
@@ -1122,7 +1149,8 @@ func TestParseAlterConnectorCoverage(t *testing.T) {
 
 	t.Run("SET OWNER ROLE", func(t *testing.T) {
 		tokens := []token.Token{
-			{Type: "ALTER", Literal: "ALTER"},
+			{Type: "ALTER",
+				ModelType: models.TokenTypeAlter, Literal: "ALTER"},
 			{Type: "CONNECTOR", Literal: "CONNECTOR"},
 			{Type: "IDENT", Literal: "my_connector"},
 			{Type: "SET", Literal: "SET"},

--- a/pkg/sql/parser/distinct_on_test.go
+++ b/pkg/sql/parser/distinct_on_test.go
@@ -4,6 +4,7 @@
 package parser
 
 import (
+	"github.com/ajitpratap0/GoSQLX/pkg/models"
 	"testing"
 
 	"github.com/ajitpratap0/GoSQLX/pkg/sql/ast"
@@ -12,7 +13,8 @@ import (
 
 func TestParser_DistinctOn_Basic(t *testing.T) {
 	tokens := []token.Token{
-		{Type: "SELECT", Literal: "SELECT"},
+		{Type: "SELECT",
+			ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 		{Type: "DISTINCT", Literal: "DISTINCT"},
 		{Type: "ON", Literal: "ON"},
 		{Type: "(", Literal: "("},
@@ -83,7 +85,8 @@ func TestParser_DistinctOn_Basic(t *testing.T) {
 
 func TestParser_DistinctOn_MultipleColumns(t *testing.T) {
 	tokens := []token.Token{
-		{Type: "SELECT", Literal: "SELECT"},
+		{Type: "SELECT",
+			ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 		{Type: "DISTINCT", Literal: "DISTINCT"},
 		{Type: "ON", Literal: "ON"},
 		{Type: "(", Literal: "("},
@@ -164,7 +167,8 @@ func TestParser_DistinctOn_MultipleColumns(t *testing.T) {
 
 func TestParser_DistinctOn_WithExpression(t *testing.T) {
 	tokens := []token.Token{
-		{Type: "SELECT", Literal: "SELECT"},
+		{Type: "SELECT",
+			ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 		{Type: "DISTINCT", Literal: "DISTINCT"},
 		{Type: "ON", Literal: "ON"},
 		{Type: "(", Literal: "("},
@@ -220,7 +224,8 @@ func TestParser_DistinctOn_WithExpression(t *testing.T) {
 
 func TestParser_DistinctOn_WithWhere(t *testing.T) {
 	tokens := []token.Token{
-		{Type: "SELECT", Literal: "SELECT"},
+		{Type: "SELECT",
+			ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 		{Type: "DISTINCT", Literal: "DISTINCT"},
 		{Type: "ON", Literal: "ON"},
 		{Type: "(", Literal: "("},
@@ -277,7 +282,8 @@ func TestParser_DistinctOn_WithWhere(t *testing.T) {
 
 func TestParser_DistinctOn_QualifiedColumn(t *testing.T) {
 	tokens := []token.Token{
-		{Type: "SELECT", Literal: "SELECT"},
+		{Type: "SELECT",
+			ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 		{Type: "DISTINCT", Literal: "DISTINCT"},
 		{Type: "ON", Literal: "ON"},
 		{Type: "(", Literal: "("},
@@ -332,7 +338,8 @@ func TestParser_DistinctOn_QualifiedColumn(t *testing.T) {
 
 func TestParser_DistinctWithoutOn_StillWorks(t *testing.T) {
 	tokens := []token.Token{
-		{Type: "SELECT", Literal: "SELECT"},
+		{Type: "SELECT",
+			ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 		{Type: "DISTINCT", Literal: "DISTINCT"},
 		{Type: "IDENT", Literal: "dept_id"},
 		{Type: ",", Literal: ","},
@@ -379,7 +386,8 @@ func TestParser_DistinctWithoutOn_StillWorks(t *testing.T) {
 
 func TestParser_DistinctOn_ErrorMissingParenthesis(t *testing.T) {
 	tokens := []token.Token{
-		{Type: "SELECT", Literal: "SELECT"},
+		{Type: "SELECT",
+			ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 		{Type: "DISTINCT", Literal: "DISTINCT"},
 		{Type: "ON", Literal: "ON"},
 		{Type: "IDENT", Literal: "dept_id"},
@@ -398,7 +406,8 @@ func TestParser_DistinctOn_ErrorMissingParenthesis(t *testing.T) {
 
 func TestParser_DistinctOn_ErrorMissingClosingParenthesis(t *testing.T) {
 	tokens := []token.Token{
-		{Type: "SELECT", Literal: "SELECT"},
+		{Type: "SELECT",
+			ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 		{Type: "DISTINCT", Literal: "DISTINCT"},
 		{Type: "ON", Literal: "ON"},
 		{Type: "(", Literal: "("},
@@ -419,7 +428,8 @@ func TestParser_DistinctOn_ErrorMissingClosingParenthesis(t *testing.T) {
 
 func TestParser_DistinctOn_WithLimit(t *testing.T) {
 	tokens := []token.Token{
-		{Type: "SELECT", Literal: "SELECT"},
+		{Type: "SELECT",
+			ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 		{Type: "DISTINCT", Literal: "DISTINCT"},
 		{Type: "ON", Literal: "ON"},
 		{Type: "(", Literal: "("},

--- a/pkg/sql/parser/error_recovery_test.go
+++ b/pkg/sql/parser/error_recovery_test.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"github.com/ajitpratap0/GoSQLX/pkg/models"
 	"strings"
 	"testing"
 
@@ -18,7 +19,8 @@ func TestParser_ErrorRecovery_SELECT(t *testing.T) {
 		{
 			name: "missing FROM keyword",
 			tokens: []token.Token{
-				{Type: "SELECT", Literal: "SELECT"},
+				{Type: "SELECT",
+					ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 				{Type: "*", Literal: "*"},
 				{Type: "IDENT", Literal: "users"}, // Missing FROM
 			},
@@ -28,7 +30,8 @@ func TestParser_ErrorRecovery_SELECT(t *testing.T) {
 		{
 			name: "missing table name after FROM",
 			tokens: []token.Token{
-				{Type: "SELECT", Literal: "SELECT"},
+				{Type: "SELECT",
+					ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 				{Type: "*", Literal: "*"},
 				{Type: "FROM", Literal: "FROM"},
 				{Type: "WHERE", Literal: "WHERE"}, // Missing table name
@@ -39,7 +42,8 @@ func TestParser_ErrorRecovery_SELECT(t *testing.T) {
 		{
 			name: "missing expression after WHERE",
 			tokens: []token.Token{
-				{Type: "SELECT", Literal: "SELECT"},
+				{Type: "SELECT",
+					ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 				{Type: "*", Literal: "*"},
 				{Type: "FROM", Literal: "FROM"},
 				{Type: "IDENT", Literal: "users"},
@@ -52,7 +56,8 @@ func TestParser_ErrorRecovery_SELECT(t *testing.T) {
 		{
 			name: "missing column name in SELECT list",
 			tokens: []token.Token{
-				{Type: "SELECT", Literal: "SELECT"},
+				{Type: "SELECT",
+					ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 				{Type: ",", Literal: ","}, // Missing column before comma
 				{Type: "IDENT", Literal: "name"},
 				{Type: "FROM", Literal: "FROM"},
@@ -64,7 +69,8 @@ func TestParser_ErrorRecovery_SELECT(t *testing.T) {
 		{
 			name: "invalid JOIN without table",
 			tokens: []token.Token{
-				{Type: "SELECT", Literal: "SELECT"},
+				{Type: "SELECT",
+					ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 				{Type: "*", Literal: "*"},
 				{Type: "FROM", Literal: "FROM"},
 				{Type: "IDENT", Literal: "users"},
@@ -77,7 +83,8 @@ func TestParser_ErrorRecovery_SELECT(t *testing.T) {
 		{
 			name: "JOIN without ON or USING clause",
 			tokens: []token.Token{
-				{Type: "SELECT", Literal: "SELECT"},
+				{Type: "SELECT",
+					ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 				{Type: "*", Literal: "*"},
 				{Type: "FROM", Literal: "FROM"},
 				{Type: "IDENT", Literal: "users"},
@@ -91,7 +98,8 @@ func TestParser_ErrorRecovery_SELECT(t *testing.T) {
 		{
 			name: "missing condition after ON in JOIN",
 			tokens: []token.Token{
-				{Type: "SELECT", Literal: "SELECT"},
+				{Type: "SELECT",
+					ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 				{Type: "*", Literal: "*"},
 				{Type: "FROM", Literal: "FROM"},
 				{Type: "IDENT", Literal: "users"},
@@ -106,7 +114,8 @@ func TestParser_ErrorRecovery_SELECT(t *testing.T) {
 		{
 			name: "missing column list in USING clause",
 			tokens: []token.Token{
-				{Type: "SELECT", Literal: "SELECT"},
+				{Type: "SELECT",
+					ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 				{Type: "*", Literal: "*"},
 				{Type: "FROM", Literal: "FROM"},
 				{Type: "IDENT", Literal: "users"},
@@ -122,7 +131,8 @@ func TestParser_ErrorRecovery_SELECT(t *testing.T) {
 		{
 			name: "missing ORDER BY columns",
 			tokens: []token.Token{
-				{Type: "SELECT", Literal: "SELECT"},
+				{Type: "SELECT",
+					ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 				{Type: "*", Literal: "*"},
 				{Type: "FROM", Literal: "FROM"},
 				{Type: "IDENT", Literal: "users"},
@@ -136,7 +146,8 @@ func TestParser_ErrorRecovery_SELECT(t *testing.T) {
 		{
 			name: "missing GROUP BY columns",
 			tokens: []token.Token{
-				{Type: "SELECT", Literal: "SELECT"},
+				{Type: "SELECT",
+					ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 				{Type: "*", Literal: "*"},
 				{Type: "FROM", Literal: "FROM"},
 				{Type: "IDENT", Literal: "users"},
@@ -180,7 +191,8 @@ func TestParser_ErrorRecovery_INSERT(t *testing.T) {
 		{
 			name: "missing INTO keyword",
 			tokens: []token.Token{
-				{Type: "INSERT", Literal: "INSERT"},
+				{Type: "INSERT",
+					ModelType: models.TokenTypeInsert, Literal: "INSERT"},
 				{Type: "IDENT", Literal: "users"}, // Missing INTO
 			},
 			wantErr:       true,
@@ -189,7 +201,8 @@ func TestParser_ErrorRecovery_INSERT(t *testing.T) {
 		{
 			name: "missing table name after INTO",
 			tokens: []token.Token{
-				{Type: "INSERT", Literal: "INSERT"},
+				{Type: "INSERT",
+					ModelType: models.TokenTypeInsert, Literal: "INSERT"},
 				{Type: "INTO", Literal: "INTO"},
 				{Type: "VALUES", Literal: "VALUES"}, // Missing table name
 			},
@@ -199,7 +212,8 @@ func TestParser_ErrorRecovery_INSERT(t *testing.T) {
 		{
 			name: "missing VALUES keyword",
 			tokens: []token.Token{
-				{Type: "INSERT", Literal: "INSERT"},
+				{Type: "INSERT",
+					ModelType: models.TokenTypeInsert, Literal: "INSERT"},
 				{Type: "INTO", Literal: "INTO"},
 				{Type: "IDENT", Literal: "users"},
 				{Type: "(", Literal: "("},
@@ -213,7 +227,8 @@ func TestParser_ErrorRecovery_INSERT(t *testing.T) {
 		{
 			name: "missing opening parenthesis in VALUES",
 			tokens: []token.Token{
-				{Type: "INSERT", Literal: "INSERT"},
+				{Type: "INSERT",
+					ModelType: models.TokenTypeInsert, Literal: "INSERT"},
 				{Type: "INTO", Literal: "INTO"},
 				{Type: "IDENT", Literal: "users"},
 				{Type: "VALUES", Literal: "VALUES"},
@@ -225,7 +240,8 @@ func TestParser_ErrorRecovery_INSERT(t *testing.T) {
 		{
 			name: "empty VALUES clause",
 			tokens: []token.Token{
-				{Type: "INSERT", Literal: "INSERT"},
+				{Type: "INSERT",
+					ModelType: models.TokenTypeInsert, Literal: "INSERT"},
 				{Type: "INTO", Literal: "INTO"},
 				{Type: "IDENT", Literal: "users"},
 				{Type: "VALUES", Literal: "VALUES"},
@@ -238,7 +254,8 @@ func TestParser_ErrorRecovery_INSERT(t *testing.T) {
 		{
 			name: "missing closing parenthesis in column list",
 			tokens: []token.Token{
-				{Type: "INSERT", Literal: "INSERT"},
+				{Type: "INSERT",
+					ModelType: models.TokenTypeInsert, Literal: "INSERT"},
 				{Type: "INTO", Literal: "INTO"},
 				{Type: "IDENT", Literal: "users"},
 				{Type: "(", Literal: "("},
@@ -284,7 +301,8 @@ func TestParser_ErrorRecovery_UPDATE(t *testing.T) {
 		{
 			name: "missing table name",
 			tokens: []token.Token{
-				{Type: "UPDATE", Literal: "UPDATE"},
+				{Type: "UPDATE",
+					ModelType: models.TokenTypeUpdate, Literal: "UPDATE"},
 				{Type: "SET", Literal: "SET"}, // Missing table name
 			},
 			wantErr:       true,
@@ -293,7 +311,8 @@ func TestParser_ErrorRecovery_UPDATE(t *testing.T) {
 		{
 			name: "missing SET keyword",
 			tokens: []token.Token{
-				{Type: "UPDATE", Literal: "UPDATE"},
+				{Type: "UPDATE",
+					ModelType: models.TokenTypeUpdate, Literal: "UPDATE"},
 				{Type: "IDENT", Literal: "users"},
 				{Type: "IDENT", Literal: "name"}, // Missing SET
 			},
@@ -303,7 +322,8 @@ func TestParser_ErrorRecovery_UPDATE(t *testing.T) {
 		{
 			name: "missing assignment in SET",
 			tokens: []token.Token{
-				{Type: "UPDATE", Literal: "UPDATE"},
+				{Type: "UPDATE",
+					ModelType: models.TokenTypeUpdate, Literal: "UPDATE"},
 				{Type: "IDENT", Literal: "users"},
 				{Type: "SET", Literal: "SET"},
 				{Type: "WHERE", Literal: "WHERE"}, // Missing assignment
@@ -314,7 +334,8 @@ func TestParser_ErrorRecovery_UPDATE(t *testing.T) {
 		{
 			name: "missing value after equals in SET",
 			tokens: []token.Token{
-				{Type: "UPDATE", Literal: "UPDATE"},
+				{Type: "UPDATE",
+					ModelType: models.TokenTypeUpdate, Literal: "UPDATE"},
 				{Type: "IDENT", Literal: "users"},
 				{Type: "SET", Literal: "SET"},
 				{Type: "IDENT", Literal: "name"},
@@ -357,7 +378,8 @@ func TestParser_ErrorRecovery_DELETE(t *testing.T) {
 		{
 			name: "missing FROM keyword",
 			tokens: []token.Token{
-				{Type: "DELETE", Literal: "DELETE"},
+				{Type: "DELETE",
+					ModelType: models.TokenTypeDelete, Literal: "DELETE"},
 				{Type: "IDENT", Literal: "users"}, // Missing FROM
 			},
 			wantErr:       true,
@@ -366,7 +388,8 @@ func TestParser_ErrorRecovery_DELETE(t *testing.T) {
 		{
 			name: "missing table name after FROM",
 			tokens: []token.Token{
-				{Type: "DELETE", Literal: "DELETE"},
+				{Type: "DELETE",
+					ModelType: models.TokenTypeDelete, Literal: "DELETE"},
 				{Type: "FROM", Literal: "FROM"},
 				{Type: "WHERE", Literal: "WHERE"}, // Missing table name
 			},
@@ -376,7 +399,8 @@ func TestParser_ErrorRecovery_DELETE(t *testing.T) {
 		{
 			name: "missing condition after WHERE",
 			tokens: []token.Token{
-				{Type: "DELETE", Literal: "DELETE"},
+				{Type: "DELETE",
+					ModelType: models.TokenTypeDelete, Literal: "DELETE"},
 				{Type: "FROM", Literal: "FROM"},
 				{Type: "IDENT", Literal: "users"},
 				{Type: "WHERE", Literal: "WHERE"},
@@ -418,7 +442,8 @@ func TestParser_ErrorRecovery_CTE(t *testing.T) {
 		{
 			name: "missing CTE name after WITH",
 			tokens: []token.Token{
-				{Type: "WITH", Literal: "WITH"},
+				{Type: "WITH",
+					ModelType: models.TokenTypeWith, Literal: "WITH"},
 				{Type: "AS", Literal: "AS"}, // Missing CTE name
 			},
 			wantErr:       true,
@@ -427,7 +452,8 @@ func TestParser_ErrorRecovery_CTE(t *testing.T) {
 		{
 			name: "missing AS keyword in CTE",
 			tokens: []token.Token{
-				{Type: "WITH", Literal: "WITH"},
+				{Type: "WITH",
+					ModelType: models.TokenTypeWith, Literal: "WITH"},
 				{Type: "IDENT", Literal: "temp"},
 				{Type: "(", Literal: "("}, // Missing AS
 			},
@@ -437,7 +463,8 @@ func TestParser_ErrorRecovery_CTE(t *testing.T) {
 		{
 			name: "missing opening parenthesis after AS",
 			tokens: []token.Token{
-				{Type: "WITH", Literal: "WITH"},
+				{Type: "WITH",
+					ModelType: models.TokenTypeWith, Literal: "WITH"},
 				{Type: "IDENT", Literal: "temp"},
 				{Type: "AS", Literal: "AS"},
 				{Type: "SELECT", Literal: "SELECT"}, // Missing (
@@ -448,7 +475,8 @@ func TestParser_ErrorRecovery_CTE(t *testing.T) {
 		{
 			name: "empty CTE query",
 			tokens: []token.Token{
-				{Type: "WITH", Literal: "WITH"},
+				{Type: "WITH",
+					ModelType: models.TokenTypeWith, Literal: "WITH"},
 				{Type: "IDENT", Literal: "temp"},
 				{Type: "AS", Literal: "AS"},
 				{Type: "(", Literal: "("},
@@ -460,7 +488,8 @@ func TestParser_ErrorRecovery_CTE(t *testing.T) {
 		{
 			name: "missing closing parenthesis in CTE",
 			tokens: []token.Token{
-				{Type: "WITH", Literal: "WITH"},
+				{Type: "WITH",
+					ModelType: models.TokenTypeWith, Literal: "WITH"},
 				{Type: "IDENT", Literal: "temp"},
 				{Type: "AS", Literal: "AS"},
 				{Type: "(", Literal: "("},
@@ -477,7 +506,8 @@ func TestParser_ErrorRecovery_CTE(t *testing.T) {
 		{
 			name: "missing main query after CTE",
 			tokens: []token.Token{
-				{Type: "WITH", Literal: "WITH"},
+				{Type: "WITH",
+					ModelType: models.TokenTypeWith, Literal: "WITH"},
 				{Type: "IDENT", Literal: "temp"},
 				{Type: "AS", Literal: "AS"},
 				{Type: "(", Literal: "("},
@@ -530,7 +560,8 @@ func TestParser_ErrorRecovery_SetOperations(t *testing.T) {
 		{
 			name: "missing right SELECT after UNION",
 			tokens: []token.Token{
-				{Type: "SELECT", Literal: "SELECT"},
+				{Type: "SELECT",
+					ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 				{Type: "*", Literal: "*"},
 				{Type: "FROM", Literal: "FROM"},
 				{Type: "IDENT", Literal: "users"},
@@ -543,7 +574,8 @@ func TestParser_ErrorRecovery_SetOperations(t *testing.T) {
 		{
 			name: "invalid token after UNION",
 			tokens: []token.Token{
-				{Type: "SELECT", Literal: "SELECT"},
+				{Type: "SELECT",
+					ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 				{Type: "*", Literal: "*"},
 				{Type: "FROM", Literal: "FROM"},
 				{Type: "IDENT", Literal: "users"},
@@ -556,7 +588,8 @@ func TestParser_ErrorRecovery_SetOperations(t *testing.T) {
 		{
 			name: "missing right SELECT after EXCEPT",
 			tokens: []token.Token{
-				{Type: "SELECT", Literal: "SELECT"},
+				{Type: "SELECT",
+					ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 				{Type: "*", Literal: "*"},
 				{Type: "FROM", Literal: "FROM"},
 				{Type: "IDENT", Literal: "users"},
@@ -569,7 +602,8 @@ func TestParser_ErrorRecovery_SetOperations(t *testing.T) {
 		{
 			name: "missing right SELECT after INTERSECT",
 			tokens: []token.Token{
-				{Type: "SELECT", Literal: "SELECT"},
+				{Type: "SELECT",
+					ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 				{Type: "*", Literal: "*"},
 				{Type: "FROM", Literal: "FROM"},
 				{Type: "IDENT", Literal: "users"},
@@ -612,7 +646,8 @@ func TestParser_ErrorRecovery_WindowFunctions(t *testing.T) {
 		{
 			name: "missing opening parenthesis after OVER",
 			tokens: []token.Token{
-				{Type: "SELECT", Literal: "SELECT"},
+				{Type: "SELECT",
+					ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 				{Type: "IDENT", Literal: "ROW_NUMBER"},
 				{Type: "(", Literal: "("},
 				{Type: ")", Literal: ")"},
@@ -625,7 +660,8 @@ func TestParser_ErrorRecovery_WindowFunctions(t *testing.T) {
 		{
 			name: "empty OVER clause",
 			tokens: []token.Token{
-				{Type: "SELECT", Literal: "SELECT"},
+				{Type: "SELECT",
+					ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 				{Type: "IDENT", Literal: "ROW_NUMBER"},
 				{Type: "(", Literal: "("},
 				{Type: ")", Literal: ")"},
@@ -640,7 +676,8 @@ func TestParser_ErrorRecovery_WindowFunctions(t *testing.T) {
 		{
 			name: "missing columns after PARTITION BY",
 			tokens: []token.Token{
-				{Type: "SELECT", Literal: "SELECT"},
+				{Type: "SELECT",
+					ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 				{Type: "IDENT", Literal: "ROW_NUMBER"},
 				{Type: "(", Literal: "("},
 				{Type: ")", Literal: ")"},
@@ -656,7 +693,8 @@ func TestParser_ErrorRecovery_WindowFunctions(t *testing.T) {
 		{
 			name: "missing columns after ORDER BY in window",
 			tokens: []token.Token{
-				{Type: "SELECT", Literal: "SELECT"},
+				{Type: "SELECT",
+					ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 				{Type: "IDENT", Literal: "ROW_NUMBER"},
 				{Type: "(", Literal: "("},
 				{Type: ")", Literal: ")"},
@@ -700,7 +738,8 @@ func TestParser_ErrorRecovery_ParserState(t *testing.T) {
 		{
 			name: "parser state after SELECT error",
 			tokens: []token.Token{
-				{Type: "SELECT", Literal: "SELECT"},
+				{Type: "SELECT",
+					ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 				{Type: "*", Literal: "*"},
 				// Missing FROM - will cause error
 			},
@@ -708,7 +747,8 @@ func TestParser_ErrorRecovery_ParserState(t *testing.T) {
 		{
 			name: "parser state after INSERT error",
 			tokens: []token.Token{
-				{Type: "INSERT", Literal: "INSERT"},
+				{Type: "INSERT",
+					ModelType: models.TokenTypeInsert, Literal: "INSERT"},
 				{Type: "INTO", Literal: "INTO"},
 				// Missing table name - will cause error
 			},
@@ -716,7 +756,8 @@ func TestParser_ErrorRecovery_ParserState(t *testing.T) {
 		{
 			name: "parser state after UPDATE error",
 			tokens: []token.Token{
-				{Type: "UPDATE", Literal: "UPDATE"},
+				{Type: "UPDATE",
+					ModelType: models.TokenTypeUpdate, Literal: "UPDATE"},
 				{Type: "IDENT", Literal: "users"},
 				// Missing SET - will cause error
 			},
@@ -755,7 +796,8 @@ func TestParser_ErrorRecovery_NoCascadingErrors(t *testing.T) {
 		{
 			name: "missing FROM doesn't cascade",
 			tokens: []token.Token{
-				{Type: "SELECT", Literal: "SELECT"},
+				{Type: "SELECT",
+					ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 				{Type: "*", Literal: "*"},
 				{Type: "IDENT", Literal: "users"}, // Missing FROM
 				{Type: "WHERE", Literal: "WHERE"},
@@ -768,7 +810,8 @@ func TestParser_ErrorRecovery_NoCascadingErrors(t *testing.T) {
 		{
 			name: "missing VALUES doesn't cascade",
 			tokens: []token.Token{
-				{Type: "INSERT", Literal: "INSERT"},
+				{Type: "INSERT",
+					ModelType: models.TokenTypeInsert, Literal: "INSERT"},
 				{Type: "INTO", Literal: "INTO"},
 				{Type: "IDENT", Literal: "users"},
 				{Type: "(", Literal: "("},
@@ -819,7 +862,8 @@ func TestParser_ErrorRecovery_ALTER(t *testing.T) {
 		{
 			name: "missing object type after ALTER",
 			tokens: []token.Token{
-				{Type: "ALTER", Literal: "ALTER"},
+				{Type: "ALTER",
+					ModelType: models.TokenTypeAlter, Literal: "ALTER"},
 				{Type: "IDENT", Literal: "users"}, // Missing TABLE/ROLE/POLICY/CONNECTOR
 			},
 			wantErr:       true,
@@ -828,7 +872,8 @@ func TestParser_ErrorRecovery_ALTER(t *testing.T) {
 		{
 			name: "missing table name after ALTER TABLE",
 			tokens: []token.Token{
-				{Type: "ALTER", Literal: "ALTER"},
+				{Type: "ALTER",
+					ModelType: models.TokenTypeAlter, Literal: "ALTER"},
 				{Type: "TABLE", Literal: "TABLE"},
 				{Type: "ADD", Literal: "ADD"}, // Missing table name
 			},
@@ -838,7 +883,8 @@ func TestParser_ErrorRecovery_ALTER(t *testing.T) {
 		{
 			name: "missing operation after table name",
 			tokens: []token.Token{
-				{Type: "ALTER", Literal: "ALTER"},
+				{Type: "ALTER",
+					ModelType: models.TokenTypeAlter, Literal: "ALTER"},
 				{Type: "TABLE", Literal: "TABLE"},
 				{Type: "IDENT", Literal: "users"},
 				// Missing ADD/DROP/RENAME/ALTER
@@ -849,7 +895,8 @@ func TestParser_ErrorRecovery_ALTER(t *testing.T) {
 		{
 			name: "missing COLUMN or CONSTRAINT after ADD",
 			tokens: []token.Token{
-				{Type: "ALTER", Literal: "ALTER"},
+				{Type: "ALTER",
+					ModelType: models.TokenTypeAlter, Literal: "ALTER"},
 				{Type: "TABLE", Literal: "TABLE"},
 				{Type: "IDENT", Literal: "users"},
 				{Type: "ADD", Literal: "ADD"},
@@ -861,7 +908,8 @@ func TestParser_ErrorRecovery_ALTER(t *testing.T) {
 		{
 			name: "missing column definition after ADD COLUMN",
 			tokens: []token.Token{
-				{Type: "ALTER", Literal: "ALTER"},
+				{Type: "ALTER",
+					ModelType: models.TokenTypeAlter, Literal: "ALTER"},
 				{Type: "TABLE", Literal: "TABLE"},
 				{Type: "IDENT", Literal: "users"},
 				{Type: "ADD", Literal: "ADD"},
@@ -874,7 +922,8 @@ func TestParser_ErrorRecovery_ALTER(t *testing.T) {
 		{
 			name: "missing constraint definition after ADD CONSTRAINT",
 			tokens: []token.Token{
-				{Type: "ALTER", Literal: "ALTER"},
+				{Type: "ALTER",
+					ModelType: models.TokenTypeAlter, Literal: "ALTER"},
 				{Type: "TABLE", Literal: "TABLE"},
 				{Type: "IDENT", Literal: "users"},
 				{Type: "ADD", Literal: "ADD"},
@@ -887,7 +936,8 @@ func TestParser_ErrorRecovery_ALTER(t *testing.T) {
 		{
 			name: "missing COLUMN or CONSTRAINT after DROP",
 			tokens: []token.Token{
-				{Type: "ALTER", Literal: "ALTER"},
+				{Type: "ALTER",
+					ModelType: models.TokenTypeAlter, Literal: "ALTER"},
 				{Type: "TABLE", Literal: "TABLE"},
 				{Type: "IDENT", Literal: "users"},
 				{Type: "DROP", Literal: "DROP"},
@@ -899,7 +949,8 @@ func TestParser_ErrorRecovery_ALTER(t *testing.T) {
 		{
 			name: "missing TO or COLUMN after RENAME",
 			tokens: []token.Token{
-				{Type: "ALTER", Literal: "ALTER"},
+				{Type: "ALTER",
+					ModelType: models.TokenTypeAlter, Literal: "ALTER"},
 				{Type: "TABLE", Literal: "TABLE"},
 				{Type: "IDENT", Literal: "users"},
 				{Type: "RENAME", Literal: "RENAME"},
@@ -911,7 +962,8 @@ func TestParser_ErrorRecovery_ALTER(t *testing.T) {
 		{
 			name: "missing TO keyword in RENAME COLUMN",
 			tokens: []token.Token{
-				{Type: "ALTER", Literal: "ALTER"},
+				{Type: "ALTER",
+					ModelType: models.TokenTypeAlter, Literal: "ALTER"},
 				{Type: "TABLE", Literal: "TABLE"},
 				{Type: "IDENT", Literal: "users"},
 				{Type: "RENAME", Literal: "RENAME"},
@@ -925,7 +977,8 @@ func TestParser_ErrorRecovery_ALTER(t *testing.T) {
 		{
 			name: "missing COLUMN after ALTER",
 			tokens: []token.Token{
-				{Type: "ALTER", Literal: "ALTER"},
+				{Type: "ALTER",
+					ModelType: models.TokenTypeAlter, Literal: "ALTER"},
 				{Type: "TABLE", Literal: "TABLE"},
 				{Type: "IDENT", Literal: "users"},
 				{Type: "ALTER", Literal: "ALTER"},
@@ -967,7 +1020,8 @@ func TestParser_ErrorRecovery_Expressions(t *testing.T) {
 		{
 			name: "unexpected token in expression",
 			tokens: []token.Token{
-				{Type: "SELECT", Literal: "SELECT"},
+				{Type: "SELECT",
+					ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 				{Type: "WHERE", Literal: "WHERE"}, // Invalid token for expression
 				{Type: "FROM", Literal: "FROM"},
 				{Type: "IDENT", Literal: "users"},
@@ -978,7 +1032,8 @@ func TestParser_ErrorRecovery_Expressions(t *testing.T) {
 		{
 			name: "missing right operand in binary expression",
 			tokens: []token.Token{
-				{Type: "SELECT", Literal: "SELECT"},
+				{Type: "SELECT",
+					ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 				{Type: "*", Literal: "*"},
 				{Type: "FROM", Literal: "FROM"},
 				{Type: "IDENT", Literal: "users"},
@@ -993,7 +1048,8 @@ func TestParser_ErrorRecovery_Expressions(t *testing.T) {
 		{
 			name: "missing identifier after dot",
 			tokens: []token.Token{
-				{Type: "SELECT", Literal: "SELECT"},
+				{Type: "SELECT",
+					ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 				{Type: "IDENT", Literal: "users"},
 				{Type: ".", Literal: "."},
 				{Type: "FROM", Literal: "FROM"}, // Invalid token after dot
@@ -1036,7 +1092,8 @@ func TestParser_ErrorRecovery_FunctionCalls(t *testing.T) {
 		{
 			name: "missing opening parenthesis in function call",
 			tokens: []token.Token{
-				{Type: "SELECT", Literal: "SELECT"},
+				{Type: "SELECT",
+					ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 				{Type: "IDENT", Literal: "COUNT"},
 				{Type: "*", Literal: "*"}, // Missing (
 				{Type: "FROM", Literal: "FROM"},
@@ -1048,7 +1105,8 @@ func TestParser_ErrorRecovery_FunctionCalls(t *testing.T) {
 		{
 			name: "missing closing parenthesis in function call",
 			tokens: []token.Token{
-				{Type: "SELECT", Literal: "SELECT"},
+				{Type: "SELECT",
+					ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 				{Type: "IDENT", Literal: "COUNT"},
 				{Type: "(", Literal: "("},
 				{Type: "*", Literal: "*"},
@@ -1060,7 +1118,8 @@ func TestParser_ErrorRecovery_FunctionCalls(t *testing.T) {
 		{
 			name: "invalid function argument",
 			tokens: []token.Token{
-				{Type: "SELECT", Literal: "SELECT"},
+				{Type: "SELECT",
+					ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 				{Type: "IDENT", Literal: "SUM"},
 				{Type: "(", Literal: "("},
 				{Type: "WHERE", Literal: "WHERE"}, // Invalid argument
@@ -1071,7 +1130,8 @@ func TestParser_ErrorRecovery_FunctionCalls(t *testing.T) {
 		{
 			name: "missing comma between function arguments",
 			tokens: []token.Token{
-				{Type: "SELECT", Literal: "SELECT"},
+				{Type: "SELECT",
+					ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 				{Type: "IDENT", Literal: "CONCAT"},
 				{Type: "(", Literal: "("},
 				{Type: "STRING", Literal: "hello"},
@@ -1114,7 +1174,8 @@ func TestParser_ErrorRecovery_WindowFrames(t *testing.T) {
 		{
 			name: "missing AND in BETWEEN frame",
 			tokens: []token.Token{
-				{Type: "SELECT", Literal: "SELECT"},
+				{Type: "SELECT",
+					ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 				{Type: "IDENT", Literal: "SUM"},
 				{Type: "(", Literal: "("},
 				{Type: "IDENT", Literal: "amount"},
@@ -1133,7 +1194,8 @@ func TestParser_ErrorRecovery_WindowFrames(t *testing.T) {
 		{
 			name: "missing PRECEDING or FOLLOWING after UNBOUNDED",
 			tokens: []token.Token{
-				{Type: "SELECT", Literal: "SELECT"},
+				{Type: "SELECT",
+					ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 				{Type: "IDENT", Literal: "SUM"},
 				{Type: "(", Literal: "("},
 				{Type: "IDENT", Literal: "amount"},
@@ -1150,7 +1212,8 @@ func TestParser_ErrorRecovery_WindowFrames(t *testing.T) {
 		{
 			name: "missing ROW after CURRENT",
 			tokens: []token.Token{
-				{Type: "SELECT", Literal: "SELECT"},
+				{Type: "SELECT",
+					ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 				{Type: "IDENT", Literal: "SUM"},
 				{Type: "(", Literal: "("},
 				{Type: "IDENT", Literal: "amount"},
@@ -1167,7 +1230,8 @@ func TestParser_ErrorRecovery_WindowFrames(t *testing.T) {
 		{
 			name: "missing PRECEDING or FOLLOWING after numeric value",
 			tokens: []token.Token{
-				{Type: "SELECT", Literal: "SELECT"},
+				{Type: "SELECT",
+					ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 				{Type: "IDENT", Literal: "SUM"},
 				{Type: "(", Literal: "("},
 				{Type: "IDENT", Literal: "amount"},
@@ -1184,7 +1248,8 @@ func TestParser_ErrorRecovery_WindowFrames(t *testing.T) {
 		{
 			name: "missing BY after PARTITION",
 			tokens: []token.Token{
-				{Type: "SELECT", Literal: "SELECT"},
+				{Type: "SELECT",
+					ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 				{Type: "IDENT", Literal: "ROW_NUMBER"},
 				{Type: "(", Literal: "("},
 				{Type: ")", Literal: ")"},
@@ -1199,7 +1264,8 @@ func TestParser_ErrorRecovery_WindowFrames(t *testing.T) {
 		{
 			name: "missing BY after ORDER in window",
 			tokens: []token.Token{
-				{Type: "SELECT", Literal: "SELECT"},
+				{Type: "SELECT",
+					ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 				{Type: "IDENT", Literal: "ROW_NUMBER"},
 				{Type: "(", Literal: "("},
 				{Type: ")", Literal: ")"},
@@ -1214,7 +1280,8 @@ func TestParser_ErrorRecovery_WindowFrames(t *testing.T) {
 		{
 			name: "missing closing parenthesis in window spec",
 			tokens: []token.Token{
-				{Type: "SELECT", Literal: "SELECT"},
+				{Type: "SELECT",
+					ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 				{Type: "IDENT", Literal: "ROW_NUMBER"},
 				{Type: "(", Literal: "("},
 				{Type: ")", Literal: ")"},
@@ -1267,7 +1334,8 @@ func TestParser_ErrorRecovery_EmptyInput(t *testing.T) {
 		{
 			name: "only EOF token",
 			tokens: []token.Token{
-				{Type: "EOF", Literal: ""},
+				{Type: "EOF",
+					ModelType: models.TokenTypeEOF, Literal: ""},
 			},
 			wantErr:       true,
 			errorContains: "incomplete SQL statement",
@@ -1275,7 +1343,8 @@ func TestParser_ErrorRecovery_EmptyInput(t *testing.T) {
 		{
 			name: "only semicolon",
 			tokens: []token.Token{
-				{Type: ";", Literal: ";"},
+				{Type: ";",
+					ModelType: models.TokenTypeSemicolon, Literal: ";"},
 			},
 			wantErr:       true,
 			errorContains: "incomplete SQL statement",
@@ -1283,7 +1352,8 @@ func TestParser_ErrorRecovery_EmptyInput(t *testing.T) {
 		{
 			name: "unknown statement type",
 			tokens: []token.Token{
-				{Type: "UNKNOWN", Literal: "UNKNOWN"},
+				{Type: "UNKNOWN",
+					ModelType: models.TokenTypeKeyword, Literal: "UNKNOWN"},
 			},
 			wantErr:       true,
 			errorContains: "statement",
@@ -1321,12 +1391,14 @@ func TestParser_ErrorRecovery_SequentialParsing(t *testing.T) {
 		{
 			name: "recover after SELECT error",
 			invalidSQL: []token.Token{
-				{Type: "SELECT", Literal: "SELECT"},
+				{Type: "SELECT",
+					ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 				{Type: "*", Literal: "*"},
 				// Missing FROM
 			},
 			validSQL: []token.Token{
-				{Type: "SELECT", Literal: "SELECT"},
+				{Type: "SELECT",
+					ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 				{Type: "*", Literal: "*"},
 				{Type: "FROM", Literal: "FROM"},
 				{Type: "IDENT", Literal: "users"},
@@ -1336,12 +1408,14 @@ func TestParser_ErrorRecovery_SequentialParsing(t *testing.T) {
 		{
 			name: "recover after INSERT error",
 			invalidSQL: []token.Token{
-				{Type: "INSERT", Literal: "INSERT"},
+				{Type: "INSERT",
+					ModelType: models.TokenTypeInsert, Literal: "INSERT"},
 				{Type: "INTO", Literal: "INTO"},
 				// Missing table name
 			},
 			validSQL: []token.Token{
-				{Type: "INSERT", Literal: "INSERT"},
+				{Type: "INSERT",
+					ModelType: models.TokenTypeInsert, Literal: "INSERT"},
 				{Type: "INTO", Literal: "INTO"},
 				{Type: "IDENT", Literal: "users"},
 				{Type: "VALUES", Literal: "VALUES"},
@@ -1354,12 +1428,14 @@ func TestParser_ErrorRecovery_SequentialParsing(t *testing.T) {
 		{
 			name: "recover after UPDATE error",
 			invalidSQL: []token.Token{
-				{Type: "UPDATE", Literal: "UPDATE"},
+				{Type: "UPDATE",
+					ModelType: models.TokenTypeUpdate, Literal: "UPDATE"},
 				{Type: "IDENT", Literal: "users"},
 				// Missing SET
 			},
 			validSQL: []token.Token{
-				{Type: "UPDATE", Literal: "UPDATE"},
+				{Type: "UPDATE",
+					ModelType: models.TokenTypeUpdate, Literal: "UPDATE"},
 				{Type: "IDENT", Literal: "users"},
 				{Type: "SET", Literal: "SET"},
 				{Type: "IDENT", Literal: "name"},
@@ -1371,11 +1447,13 @@ func TestParser_ErrorRecovery_SequentialParsing(t *testing.T) {
 		{
 			name: "recover after DELETE error",
 			invalidSQL: []token.Token{
-				{Type: "DELETE", Literal: "DELETE"},
+				{Type: "DELETE",
+					ModelType: models.TokenTypeDelete, Literal: "DELETE"},
 				// Missing FROM
 			},
 			validSQL: []token.Token{
-				{Type: "DELETE", Literal: "DELETE"},
+				{Type: "DELETE",
+					ModelType: models.TokenTypeDelete, Literal: "DELETE"},
 				{Type: "FROM", Literal: "FROM"},
 				{Type: "IDENT", Literal: "users"},
 			},
@@ -1417,7 +1495,8 @@ func TestParser_ErrorRecovery_AlterRole(t *testing.T) {
 		{
 			name: "missing TO in RENAME",
 			tokens: []token.Token{
-				{Type: "ALTER", Literal: "ALTER"},
+				{Type: "ALTER",
+					ModelType: models.TokenTypeAlter, Literal: "ALTER"},
 				{Type: "ROLE", Literal: "ROLE"},
 				{Type: "IDENT", Literal: "old_role"},
 				{Type: "RENAME", Literal: "RENAME"},
@@ -1429,7 +1508,8 @@ func TestParser_ErrorRecovery_AlterRole(t *testing.T) {
 		{
 			name: "missing MEMBER after ADD",
 			tokens: []token.Token{
-				{Type: "ALTER", Literal: "ALTER"},
+				{Type: "ALTER",
+					ModelType: models.TokenTypeAlter, Literal: "ALTER"},
 				{Type: "ROLE", Literal: "ROLE"},
 				{Type: "IDENT", Literal: "role1"},
 				{Type: "ADD", Literal: "ADD"},
@@ -1441,7 +1521,8 @@ func TestParser_ErrorRecovery_AlterRole(t *testing.T) {
 		{
 			name: "missing MEMBER after DROP",
 			tokens: []token.Token{
-				{Type: "ALTER", Literal: "ALTER"},
+				{Type: "ALTER",
+					ModelType: models.TokenTypeAlter, Literal: "ALTER"},
 				{Type: "ROLE", Literal: "ROLE"},
 				{Type: "IDENT", Literal: "role1"},
 				{Type: "DROP", Literal: "DROP"},
@@ -1453,7 +1534,8 @@ func TestParser_ErrorRecovery_AlterRole(t *testing.T) {
 		{
 			name: "missing operation after role name",
 			tokens: []token.Token{
-				{Type: "ALTER", Literal: "ALTER"},
+				{Type: "ALTER",
+					ModelType: models.TokenTypeAlter, Literal: "ALTER"},
 				{Type: "ROLE", Literal: "ROLE"},
 				{Type: "IDENT", Literal: "role1"},
 				// Missing operation
@@ -1464,7 +1546,8 @@ func TestParser_ErrorRecovery_AlterRole(t *testing.T) {
 		{
 			name: "missing UNTIL after VALID",
 			tokens: []token.Token{
-				{Type: "ALTER", Literal: "ALTER"},
+				{Type: "ALTER",
+					ModelType: models.TokenTypeAlter, Literal: "ALTER"},
 				{Type: "ROLE", Literal: "ROLE"},
 				{Type: "IDENT", Literal: "role1"},
 				{Type: "WITH", Literal: "WITH"},
@@ -1507,7 +1590,8 @@ func TestParser_ErrorRecovery_AlterPolicy(t *testing.T) {
 		{
 			name: "missing ON keyword",
 			tokens: []token.Token{
-				{Type: "ALTER", Literal: "ALTER"},
+				{Type: "ALTER",
+					ModelType: models.TokenTypeAlter, Literal: "ALTER"},
 				{Type: "POLICY", Literal: "POLICY"},
 				{Type: "IDENT", Literal: "policy1"},
 				{Type: "IDENT", Literal: "table1"}, // Missing ON
@@ -1518,7 +1602,8 @@ func TestParser_ErrorRecovery_AlterPolicy(t *testing.T) {
 		{
 			name: "missing TO in RENAME",
 			tokens: []token.Token{
-				{Type: "ALTER", Literal: "ALTER"},
+				{Type: "ALTER",
+					ModelType: models.TokenTypeAlter, Literal: "ALTER"},
 				{Type: "POLICY", Literal: "POLICY"},
 				{Type: "IDENT", Literal: "policy1"},
 				{Type: "ON", Literal: "ON"},
@@ -1532,7 +1617,8 @@ func TestParser_ErrorRecovery_AlterPolicy(t *testing.T) {
 		{
 			name: "missing opening parenthesis in USING",
 			tokens: []token.Token{
-				{Type: "ALTER", Literal: "ALTER"},
+				{Type: "ALTER",
+					ModelType: models.TokenTypeAlter, Literal: "ALTER"},
 				{Type: "POLICY", Literal: "POLICY"},
 				{Type: "IDENT", Literal: "policy1"},
 				{Type: "ON", Literal: "ON"},
@@ -1546,7 +1632,8 @@ func TestParser_ErrorRecovery_AlterPolicy(t *testing.T) {
 		{
 			name: "missing closing parenthesis in USING",
 			tokens: []token.Token{
-				{Type: "ALTER", Literal: "ALTER"},
+				{Type: "ALTER",
+					ModelType: models.TokenTypeAlter, Literal: "ALTER"},
 				{Type: "POLICY", Literal: "POLICY"},
 				{Type: "IDENT", Literal: "policy1"},
 				{Type: "ON", Literal: "ON"},
@@ -1592,7 +1679,8 @@ func TestParser_ErrorRecovery_AlterConnector(t *testing.T) {
 		{
 			name: "missing SET keyword",
 			tokens: []token.Token{
-				{Type: "ALTER", Literal: "ALTER"},
+				{Type: "ALTER",
+					ModelType: models.TokenTypeAlter, Literal: "ALTER"},
 				{Type: "CONNECTOR", Literal: "CONNECTOR"},
 				{Type: "IDENT", Literal: "connector1"},
 				{Type: "URL", Literal: "URL"}, // Missing SET
@@ -1603,7 +1691,8 @@ func TestParser_ErrorRecovery_AlterConnector(t *testing.T) {
 		{
 			name: "missing property type after SET",
 			tokens: []token.Token{
-				{Type: "ALTER", Literal: "ALTER"},
+				{Type: "ALTER",
+					ModelType: models.TokenTypeAlter, Literal: "ALTER"},
 				{Type: "CONNECTOR", Literal: "CONNECTOR"},
 				{Type: "IDENT", Literal: "connector1"},
 				{Type: "SET", Literal: "SET"},
@@ -1615,7 +1704,8 @@ func TestParser_ErrorRecovery_AlterConnector(t *testing.T) {
 		{
 			name: "missing opening parenthesis in DCPROPERTIES",
 			tokens: []token.Token{
-				{Type: "ALTER", Literal: "ALTER"},
+				{Type: "ALTER",
+					ModelType: models.TokenTypeAlter, Literal: "ALTER"},
 				{Type: "CONNECTOR", Literal: "CONNECTOR"},
 				{Type: "IDENT", Literal: "connector1"},
 				{Type: "SET", Literal: "SET"},
@@ -1628,7 +1718,8 @@ func TestParser_ErrorRecovery_AlterConnector(t *testing.T) {
 		{
 			name: "missing equals in DCPROPERTIES",
 			tokens: []token.Token{
-				{Type: "ALTER", Literal: "ALTER"},
+				{Type: "ALTER",
+					ModelType: models.TokenTypeAlter, Literal: "ALTER"},
 				{Type: "CONNECTOR", Literal: "CONNECTOR"},
 				{Type: "IDENT", Literal: "connector1"},
 				{Type: "SET", Literal: "SET"},
@@ -1643,7 +1734,8 @@ func TestParser_ErrorRecovery_AlterConnector(t *testing.T) {
 		{
 			name: "missing closing parenthesis in DCPROPERTIES",
 			tokens: []token.Token{
-				{Type: "ALTER", Literal: "ALTER"},
+				{Type: "ALTER",
+					ModelType: models.TokenTypeAlter, Literal: "ALTER"},
 				{Type: "CONNECTOR", Literal: "CONNECTOR"},
 				{Type: "IDENT", Literal: "connector1"},
 				{Type: "SET", Literal: "SET"},
@@ -1660,7 +1752,8 @@ func TestParser_ErrorRecovery_AlterConnector(t *testing.T) {
 		{
 			name: "missing USER or ROLE after OWNER",
 			tokens: []token.Token{
-				{Type: "ALTER", Literal: "ALTER"},
+				{Type: "ALTER",
+					ModelType: models.TokenTypeAlter, Literal: "ALTER"},
 				{Type: "CONNECTOR", Literal: "CONNECTOR"},
 				{Type: "IDENT", Literal: "connector1"},
 				{Type: "SET", Literal: "SET"},
@@ -1699,30 +1792,30 @@ func generateDeeplyNestedCTE(depth int) []token.Token {
 	// Generate nested WITH clauses
 	for i := 0; i < depth; i++ {
 		tokens = append(tokens,
-			token.Token{Type: "WITH", Literal: "WITH"},
-			token.Token{Type: "IDENT", Literal: "cte"},
-			token.Token{Type: "AS", Literal: "AS"},
-			token.Token{Type: "(", Literal: "("},
+			token.Token{Type: "WITH", ModelType: models.TokenTypeWith, Literal: "WITH"},
+			token.Token{Type: "IDENT", ModelType: models.TokenTypeIdentifier, Literal: "cte"},
+			token.Token{Type: "AS", ModelType: models.TokenTypeAs, Literal: "AS"},
+			token.Token{Type: "(", ModelType: models.TokenTypeLParen, Literal: "("},
 		)
 	}
 
 	// Add a simple SELECT in the innermost level
 	tokens = append(tokens,
-		token.Token{Type: "SELECT", Literal: "SELECT"},
-		token.Token{Type: "INT", Literal: "1"},
+		token.Token{Type: "SELECT", ModelType: models.TokenTypeSelect, Literal: "SELECT"},
+		token.Token{Type: "INT", ModelType: models.TokenTypeNumber, Literal: "1"},
 	)
 
 	// Close all parentheses
 	for i := 0; i < depth; i++ {
-		tokens = append(tokens, token.Token{Type: ")", Literal: ")"})
+		tokens = append(tokens, token.Token{Type: ")", ModelType: models.TokenTypeRParen, Literal: ")"})
 	}
 
 	// Add final SELECT
 	tokens = append(tokens,
-		token.Token{Type: "SELECT", Literal: "SELECT"},
-		token.Token{Type: "*", Literal: "*"},
-		token.Token{Type: "FROM", Literal: "FROM"},
-		token.Token{Type: "IDENT", Literal: "cte"},
+		token.Token{Type: "SELECT", ModelType: models.TokenTypeSelect, Literal: "SELECT"},
+		token.Token{Type: "*", ModelType: models.TokenTypeAsterisk, Literal: "*"},
+		token.Token{Type: "FROM", ModelType: models.TokenTypeFrom, Literal: "FROM"},
+		token.Token{Type: "IDENT", ModelType: models.TokenTypeIdentifier, Literal: "cte"},
 	)
 
 	return tokens

--- a/pkg/sql/parser/join_test.go
+++ b/pkg/sql/parser/join_test.go
@@ -18,66 +18,66 @@ func convertTokens(tokens []models.TokenWithSpan) []token.Token {
 		// Handle compound JOIN tokens by splitting them
 		switch t.Token.Type {
 		case models.TokenTypeInnerJoin:
-			result = append(result, token.Token{Type: "INNER", Literal: "INNER"})
-			result = append(result, token.Token{Type: "JOIN", Literal: "JOIN"})
+			result = append(result, token.Token{Type: "INNER", ModelType: models.TokenTypeInner, Literal: "INNER"})
+			result = append(result, token.Token{Type: "JOIN", ModelType: models.TokenTypeJoin, Literal: "JOIN"})
 			continue
 		case models.TokenTypeLeftJoin:
-			result = append(result, token.Token{Type: "LEFT", Literal: "LEFT"})
-			result = append(result, token.Token{Type: "JOIN", Literal: "JOIN"})
+			result = append(result, token.Token{Type: "LEFT", ModelType: models.TokenTypeLeft, Literal: "LEFT"})
+			result = append(result, token.Token{Type: "JOIN", ModelType: models.TokenTypeJoin, Literal: "JOIN"})
 			continue
 		case models.TokenTypeRightJoin:
-			result = append(result, token.Token{Type: "RIGHT", Literal: "RIGHT"})
-			result = append(result, token.Token{Type: "JOIN", Literal: "JOIN"})
+			result = append(result, token.Token{Type: "RIGHT", ModelType: models.TokenTypeRight, Literal: "RIGHT"})
+			result = append(result, token.Token{Type: "JOIN", ModelType: models.TokenTypeJoin, Literal: "JOIN"})
 			continue
 		case models.TokenTypeOuterJoin:
-			result = append(result, token.Token{Type: "OUTER", Literal: "OUTER"})
-			result = append(result, token.Token{Type: "JOIN", Literal: "JOIN"})
+			result = append(result, token.Token{Type: "OUTER", ModelType: models.TokenTypeOuter, Literal: "OUTER"})
+			result = append(result, token.Token{Type: "JOIN", ModelType: models.TokenTypeJoin, Literal: "JOIN"})
 			continue
 		}
 
 		// Handle compound tokens that come as strings
 		if t.Token.Value == "INNER JOIN" {
-			result = append(result, token.Token{Type: "INNER", Literal: "INNER"})
-			result = append(result, token.Token{Type: "JOIN", Literal: "JOIN"})
+			result = append(result, token.Token{Type: "INNER", ModelType: models.TokenTypeInner, Literal: "INNER"})
+			result = append(result, token.Token{Type: "JOIN", ModelType: models.TokenTypeJoin, Literal: "JOIN"})
 			continue
 		} else if t.Token.Value == "LEFT JOIN" {
-			result = append(result, token.Token{Type: "LEFT", Literal: "LEFT"})
-			result = append(result, token.Token{Type: "JOIN", Literal: "JOIN"})
+			result = append(result, token.Token{Type: "LEFT", ModelType: models.TokenTypeLeft, Literal: "LEFT"})
+			result = append(result, token.Token{Type: "JOIN", ModelType: models.TokenTypeJoin, Literal: "JOIN"})
 			continue
 		} else if t.Token.Value == "RIGHT JOIN" {
-			result = append(result, token.Token{Type: "RIGHT", Literal: "RIGHT"})
-			result = append(result, token.Token{Type: "JOIN", Literal: "JOIN"})
+			result = append(result, token.Token{Type: "RIGHT", ModelType: models.TokenTypeRight, Literal: "RIGHT"})
+			result = append(result, token.Token{Type: "JOIN", ModelType: models.TokenTypeJoin, Literal: "JOIN"})
 			continue
 		} else if t.Token.Value == "FULL JOIN" || t.Token.Type == models.TokenTypeKeyword && t.Token.Value == "FULL JOIN" {
-			result = append(result, token.Token{Type: "FULL", Literal: "FULL"})
-			result = append(result, token.Token{Type: "JOIN", Literal: "JOIN"})
+			result = append(result, token.Token{Type: "FULL", ModelType: models.TokenTypeFull, Literal: "FULL"})
+			result = append(result, token.Token{Type: "JOIN", ModelType: models.TokenTypeJoin, Literal: "JOIN"})
 			continue
 		} else if t.Token.Value == "CROSS JOIN" || t.Token.Type == models.TokenTypeKeyword && t.Token.Value == "CROSS JOIN" {
-			result = append(result, token.Token{Type: "CROSS", Literal: "CROSS"})
-			result = append(result, token.Token{Type: "JOIN", Literal: "JOIN"})
+			result = append(result, token.Token{Type: "CROSS", ModelType: models.TokenTypeCross, Literal: "CROSS"})
+			result = append(result, token.Token{Type: "JOIN", ModelType: models.TokenTypeJoin, Literal: "JOIN"})
 			continue
 		} else if t.Token.Value == "LEFT OUTER JOIN" {
-			result = append(result, token.Token{Type: "LEFT", Literal: "LEFT"})
-			result = append(result, token.Token{Type: "OUTER", Literal: "OUTER"})
-			result = append(result, token.Token{Type: "JOIN", Literal: "JOIN"})
+			result = append(result, token.Token{Type: "LEFT", ModelType: models.TokenTypeLeft, Literal: "LEFT"})
+			result = append(result, token.Token{Type: "OUTER", ModelType: models.TokenTypeOuter, Literal: "OUTER"})
+			result = append(result, token.Token{Type: "JOIN", ModelType: models.TokenTypeJoin, Literal: "JOIN"})
 			continue
 		} else if t.Token.Value == "RIGHT OUTER JOIN" {
-			result = append(result, token.Token{Type: "RIGHT", Literal: "RIGHT"})
-			result = append(result, token.Token{Type: "OUTER", Literal: "OUTER"})
-			result = append(result, token.Token{Type: "JOIN", Literal: "JOIN"})
+			result = append(result, token.Token{Type: "RIGHT", ModelType: models.TokenTypeRight, Literal: "RIGHT"})
+			result = append(result, token.Token{Type: "OUTER", ModelType: models.TokenTypeOuter, Literal: "OUTER"})
+			result = append(result, token.Token{Type: "JOIN", ModelType: models.TokenTypeJoin, Literal: "JOIN"})
 			continue
 		} else if t.Token.Value == "FULL OUTER JOIN" {
-			result = append(result, token.Token{Type: "FULL", Literal: "FULL"})
-			result = append(result, token.Token{Type: "OUTER", Literal: "OUTER"})
-			result = append(result, token.Token{Type: "JOIN", Literal: "JOIN"})
+			result = append(result, token.Token{Type: "FULL", ModelType: models.TokenTypeFull, Literal: "FULL"})
+			result = append(result, token.Token{Type: "OUTER", ModelType: models.TokenTypeOuter, Literal: "OUTER"})
+			result = append(result, token.Token{Type: "JOIN", ModelType: models.TokenTypeJoin, Literal: "JOIN"})
 			continue
 		} else if t.Token.Value == "ORDER BY" || t.Token.Type == models.TokenTypeOrderBy {
-			result = append(result, token.Token{Type: "ORDER", Literal: "ORDER"})
-			result = append(result, token.Token{Type: "BY", Literal: "BY"})
+			result = append(result, token.Token{Type: "ORDER", ModelType: models.TokenTypeOrder, Literal: "ORDER"})
+			result = append(result, token.Token{Type: "BY", ModelType: models.TokenTypeBy, Literal: "BY"})
 			continue
 		} else if t.Token.Value == "GROUP BY" || t.Token.Type == models.TokenTypeGroupBy {
-			result = append(result, token.Token{Type: "GROUP", Literal: "GROUP"})
-			result = append(result, token.Token{Type: "BY", Literal: "BY"})
+			result = append(result, token.Token{Type: "GROUP", ModelType: models.TokenTypeGroup, Literal: "GROUP"})
+			result = append(result, token.Token{Type: "BY", ModelType: models.TokenTypeBy, Literal: "BY"})
 			continue
 		}
 

--- a/pkg/sql/parser/modeltype_helpers_test.go
+++ b/pkg/sql/parser/modeltype_helpers_test.go
@@ -35,7 +35,7 @@ func TestIsAnyType(t *testing.T) {
 		},
 		{
 			name:     "match after normalization",
-			token:    token.Token{Type: "SELECT", Literal: "SELECT"},
+			token:    token.Token{Type: "SELECT", ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 			types:    []models.TokenType{models.TokenTypeSelect, models.TokenTypeInsert},
 			expected: true,
 		},
@@ -96,7 +96,8 @@ func TestMatchType(t *testing.T) {
 		{
 			name: "match after normalization",
 			tokens: []token.Token{
-				{Type: "SELECT", Literal: "SELECT"},
+				{Type: "SELECT",
+					ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 				{Type: "FROM", Literal: "FROM"},
 			},
 			matchAgainst: models.TokenTypeSelect,
@@ -128,7 +129,8 @@ func TestMatchType(t *testing.T) {
 // from string Type for tokens that don't have ModelType set.
 func TestNormalizeTokens(t *testing.T) {
 	tokens := []token.Token{
-		{Type: "SELECT", Literal: "SELECT"},
+		{Type: "SELECT",
+			ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 		{Type: "INSERT", Literal: "INSERT"},
 		{Type: "UPDATE", Literal: "UPDATE"},
 		{Type: "DELETE", Literal: "DELETE"},

--- a/pkg/sql/parser/negative_parser_test.go
+++ b/pkg/sql/parser/negative_parser_test.go
@@ -3,6 +3,7 @@ package parser
 import (
 	"context"
 	"fmt"
+	"github.com/ajitpratap0/GoSQLX/pkg/models"
 	"strings"
 	"testing"
 	"time"
@@ -25,13 +26,15 @@ func TestNegativeParser_MalformedSQL(t *testing.T) {
 		{
 			name: "SELECT with no columns or table",
 			tokens: []token.Token{
-				{Type: "SELECT", Literal: "SELECT"},
+				{Type: "SELECT",
+					ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 			},
 		},
 		{
 			name: "SELECT FROM WHERE - no columns no table no condition",
 			tokens: []token.Token{
-				{Type: "SELECT", Literal: "SELECT"},
+				{Type: "SELECT",
+					ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 				{Type: "FROM", Literal: "FROM"},
 				{Type: "WHERE", Literal: "WHERE"},
 			},
@@ -39,7 +42,8 @@ func TestNegativeParser_MalformedSQL(t *testing.T) {
 		{
 			name: "missing FROM clause",
 			tokens: []token.Token{
-				{Type: "SELECT", Literal: "SELECT"},
+				{Type: "SELECT",
+					ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 				{Type: "IDENT", Literal: "id"},
 				{Type: "WHERE", Literal: "WHERE"},
 				{Type: "IDENT", Literal: "x"},
@@ -50,7 +54,8 @@ func TestNegativeParser_MalformedSQL(t *testing.T) {
 		{
 			name: "unclosed parenthesis in expression",
 			tokens: []token.Token{
-				{Type: "SELECT", Literal: "SELECT"},
+				{Type: "SELECT",
+					ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 				{Type: "(", Literal: "("},
 				{Type: "IDENT", Literal: "a"},
 				{Type: "+", Literal: "+"},
@@ -63,7 +68,8 @@ func TestNegativeParser_MalformedSQL(t *testing.T) {
 		{
 			name: "extra closing parenthesis",
 			tokens: []token.Token{
-				{Type: "SELECT", Literal: "SELECT"},
+				{Type: "SELECT",
+					ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 				{Type: "IDENT", Literal: "a"},
 				{Type: ")", Literal: ")"},
 				{Type: "FROM", Literal: "FROM"},
@@ -73,7 +79,8 @@ func TestNegativeParser_MalformedSQL(t *testing.T) {
 		{
 			name: "duplicate WHERE clauses",
 			tokens: []token.Token{
-				{Type: "SELECT", Literal: "SELECT"},
+				{Type: "SELECT",
+					ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 				{Type: "*", Literal: "*"},
 				{Type: "FROM", Literal: "FROM"},
 				{Type: "IDENT", Literal: "users"},
@@ -90,7 +97,8 @@ func TestNegativeParser_MalformedSQL(t *testing.T) {
 		{
 			name: "duplicate FROM clauses",
 			tokens: []token.Token{
-				{Type: "SELECT", Literal: "SELECT"},
+				{Type: "SELECT",
+					ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 				{Type: "*", Literal: "*"},
 				{Type: "FROM", Literal: "FROM"},
 				{Type: "IDENT", Literal: "t1"},
@@ -101,7 +109,8 @@ func TestNegativeParser_MalformedSQL(t *testing.T) {
 		{
 			name: "trailing garbage after valid SELECT",
 			tokens: []token.Token{
-				{Type: "SELECT", Literal: "SELECT"},
+				{Type: "SELECT",
+					ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 				{Type: "*", Literal: "*"},
 				{Type: "FROM", Literal: "FROM"},
 				{Type: "IDENT", Literal: "users"},
@@ -113,7 +122,8 @@ func TestNegativeParser_MalformedSQL(t *testing.T) {
 		{
 			name: "JOIN without ON condition",
 			tokens: []token.Token{
-				{Type: "SELECT", Literal: "SELECT"},
+				{Type: "SELECT",
+					ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 				{Type: "*", Literal: "*"},
 				{Type: "FROM", Literal: "FROM"},
 				{Type: "IDENT", Literal: "a"},
@@ -125,7 +135,8 @@ func TestNegativeParser_MalformedSQL(t *testing.T) {
 		{
 			name: "JOIN with ON but no condition",
 			tokens: []token.Token{
-				{Type: "SELECT", Literal: "SELECT"},
+				{Type: "SELECT",
+					ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 				{Type: "*", Literal: "*"},
 				{Type: "FROM", Literal: "FROM"},
 				{Type: "IDENT", Literal: "a"},
@@ -137,7 +148,8 @@ func TestNegativeParser_MalformedSQL(t *testing.T) {
 		{
 			name: "JOIN without table name",
 			tokens: []token.Token{
-				{Type: "SELECT", Literal: "SELECT"},
+				{Type: "SELECT",
+					ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 				{Type: "*", Literal: "*"},
 				{Type: "FROM", Literal: "FROM"},
 				{Type: "IDENT", Literal: "a"},
@@ -151,7 +163,8 @@ func TestNegativeParser_MalformedSQL(t *testing.T) {
 		{
 			name: "INSERT missing INTO",
 			tokens: []token.Token{
-				{Type: "INSERT", Literal: "INSERT"},
+				{Type: "INSERT",
+					ModelType: models.TokenTypeInsert, Literal: "INSERT"},
 				{Type: "IDENT", Literal: "users"},
 				{Type: "VALUES", Literal: "VALUES"},
 				{Type: "(", Literal: "("},
@@ -162,7 +175,8 @@ func TestNegativeParser_MalformedSQL(t *testing.T) {
 		{
 			name: "INSERT INTO missing VALUES",
 			tokens: []token.Token{
-				{Type: "INSERT", Literal: "INSERT"},
+				{Type: "INSERT",
+					ModelType: models.TokenTypeInsert, Literal: "INSERT"},
 				{Type: "INTO", Literal: "INTO"},
 				{Type: "IDENT", Literal: "users"},
 			},
@@ -170,7 +184,8 @@ func TestNegativeParser_MalformedSQL(t *testing.T) {
 		{
 			name: "UPDATE missing SET",
 			tokens: []token.Token{
-				{Type: "UPDATE", Literal: "UPDATE"},
+				{Type: "UPDATE",
+					ModelType: models.TokenTypeUpdate, Literal: "UPDATE"},
 				{Type: "IDENT", Literal: "users"},
 				{Type: "WHERE", Literal: "WHERE"},
 				{Type: "IDENT", Literal: "id"},
@@ -181,32 +196,37 @@ func TestNegativeParser_MalformedSQL(t *testing.T) {
 		{
 			name: "DELETE missing FROM",
 			tokens: []token.Token{
-				{Type: "DELETE", Literal: "DELETE"},
+				{Type: "DELETE",
+					ModelType: models.TokenTypeDelete, Literal: "DELETE"},
 				{Type: "IDENT", Literal: "users"},
 			},
 		},
 		{
 			name: "lone keyword WHERE",
 			tokens: []token.Token{
-				{Type: "WHERE", Literal: "WHERE"},
+				{Type: "WHERE",
+					ModelType: models.TokenTypeWhere, Literal: "WHERE"},
 			},
 		},
 		{
 			name: "lone keyword FROM",
 			tokens: []token.Token{
-				{Type: "FROM", Literal: "FROM"},
+				{Type: "FROM",
+					ModelType: models.TokenTypeFrom, Literal: "FROM"},
 			},
 		},
 		{
 			name: "lone keyword JOIN",
 			tokens: []token.Token{
-				{Type: "JOIN", Literal: "JOIN"},
+				{Type: "JOIN",
+					ModelType: models.TokenTypeJoin, Literal: "JOIN"},
 			},
 		},
 		{
 			name: "consecutive commas in SELECT list",
 			tokens: []token.Token{
-				{Type: "SELECT", Literal: "SELECT"},
+				{Type: "SELECT",
+					ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 				{Type: "IDENT", Literal: "a"},
 				{Type: ",", Literal: ","},
 				{Type: ",", Literal: ","},
@@ -218,7 +238,8 @@ func TestNegativeParser_MalformedSQL(t *testing.T) {
 		{
 			name: "trailing comma in SELECT list",
 			tokens: []token.Token{
-				{Type: "SELECT", Literal: "SELECT"},
+				{Type: "SELECT",
+					ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 				{Type: "IDENT", Literal: "a"},
 				{Type: ",", Literal: ","},
 				{Type: "FROM", Literal: "FROM"},
@@ -228,7 +249,8 @@ func TestNegativeParser_MalformedSQL(t *testing.T) {
 		{
 			name: "ORDER BY with no column",
 			tokens: []token.Token{
-				{Type: "SELECT", Literal: "SELECT"},
+				{Type: "SELECT",
+					ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 				{Type: "*", Literal: "*"},
 				{Type: "FROM", Literal: "FROM"},
 				{Type: "IDENT", Literal: "t"},
@@ -239,7 +261,8 @@ func TestNegativeParser_MalformedSQL(t *testing.T) {
 		{
 			name: "GROUP BY with no column",
 			tokens: []token.Token{
-				{Type: "SELECT", Literal: "SELECT"},
+				{Type: "SELECT",
+					ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 				{Type: "*", Literal: "*"},
 				{Type: "FROM", Literal: "FROM"},
 				{Type: "IDENT", Literal: "t"},
@@ -250,7 +273,8 @@ func TestNegativeParser_MalformedSQL(t *testing.T) {
 		{
 			name: "HAVING without GROUP BY",
 			tokens: []token.Token{
-				{Type: "SELECT", Literal: "SELECT"},
+				{Type: "SELECT",
+					ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 				{Type: "*", Literal: "*"},
 				{Type: "FROM", Literal: "FROM"},
 				{Type: "IDENT", Literal: "t"},
@@ -263,7 +287,8 @@ func TestNegativeParser_MalformedSQL(t *testing.T) {
 		{
 			name: "malformed subquery - unclosed",
 			tokens: []token.Token{
-				{Type: "SELECT", Literal: "SELECT"},
+				{Type: "SELECT",
+					ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 				{Type: "(", Literal: "("},
 				{Type: "SELECT", Literal: "SELECT"},
 				{Type: "INT", Literal: "1"},
@@ -275,7 +300,8 @@ func TestNegativeParser_MalformedSQL(t *testing.T) {
 		{
 			name: "nested unclosed parentheses",
 			tokens: []token.Token{
-				{Type: "SELECT", Literal: "SELECT"},
+				{Type: "SELECT",
+					ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 				{Type: "(", Literal: "("},
 				{Type: "(", Literal: "("},
 				{Type: "IDENT", Literal: "a"},
@@ -288,7 +314,8 @@ func TestNegativeParser_MalformedSQL(t *testing.T) {
 		{
 			name: "operator with no operands",
 			tokens: []token.Token{
-				{Type: "SELECT", Literal: "SELECT"},
+				{Type: "SELECT",
+					ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 				{Type: "+", Literal: "+"},
 				{Type: "FROM", Literal: "FROM"},
 				{Type: "IDENT", Literal: "t"},
@@ -297,7 +324,8 @@ func TestNegativeParser_MalformedSQL(t *testing.T) {
 		{
 			name: "dangling AND in WHERE",
 			tokens: []token.Token{
-				{Type: "SELECT", Literal: "SELECT"},
+				{Type: "SELECT",
+					ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 				{Type: "*", Literal: "*"},
 				{Type: "FROM", Literal: "FROM"},
 				{Type: "IDENT", Literal: "t"},
@@ -312,7 +340,8 @@ func TestNegativeParser_MalformedSQL(t *testing.T) {
 		{
 			name: "dangling OR in WHERE",
 			tokens: []token.Token{
-				{Type: "SELECT", Literal: "SELECT"},
+				{Type: "SELECT",
+					ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 				{Type: "*", Literal: "*"},
 				{Type: "FROM", Literal: "FROM"},
 				{Type: "IDENT", Literal: "t"},
@@ -326,7 +355,8 @@ func TestNegativeParser_MalformedSQL(t *testing.T) {
 		{
 			name: "CREATE TABLE with no columns",
 			tokens: []token.Token{
-				{Type: "CREATE", Literal: "CREATE"},
+				{Type: "CREATE",
+					ModelType: models.TokenTypeCreate, Literal: "CREATE"},
 				{Type: "TABLE", Literal: "TABLE"},
 				{Type: "IDENT", Literal: "t"},
 				{Type: "(", Literal: "("},
@@ -336,7 +366,8 @@ func TestNegativeParser_MalformedSQL(t *testing.T) {
 		{
 			name: "only semicolons",
 			tokens: []token.Token{
-				{Type: ";", Literal: ";"},
+				{Type: ";",
+					ModelType: models.TokenTypeSemicolon, Literal: ";"},
 				{Type: ";", Literal: ";"},
 				{Type: ";", Literal: ";"},
 			},
@@ -344,7 +375,8 @@ func TestNegativeParser_MalformedSQL(t *testing.T) {
 		{
 			name: "LIMIT without value",
 			tokens: []token.Token{
-				{Type: "SELECT", Literal: "SELECT"},
+				{Type: "SELECT",
+					ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 				{Type: "*", Literal: "*"},
 				{Type: "FROM", Literal: "FROM"},
 				{Type: "IDENT", Literal: "t"},
@@ -354,7 +386,8 @@ func TestNegativeParser_MalformedSQL(t *testing.T) {
 		{
 			name: "OFFSET without value",
 			tokens: []token.Token{
-				{Type: "SELECT", Literal: "SELECT"},
+				{Type: "SELECT",
+					ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 				{Type: "*", Literal: "*"},
 				{Type: "FROM", Literal: "FROM"},
 				{Type: "IDENT", Literal: "t"},
@@ -462,7 +495,8 @@ func tokenizeForTest(t *testing.T, sql string) []token.Token {
 func TestPoolContamination(t *testing.T) {
 	// Pattern A: simple SELECT
 	tokensA := []token.Token{
-		{Type: "SELECT", Literal: "SELECT"},
+		{Type: "SELECT",
+			ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 		{Type: "IDENT", Literal: "id"},
 		{Type: ",", Literal: ","},
 		{Type: "IDENT", Literal: "name"},
@@ -476,7 +510,8 @@ func TestPoolContamination(t *testing.T) {
 
 	// Pattern B: INSERT
 	tokensB := []token.Token{
-		{Type: "INSERT", Literal: "INSERT"},
+		{Type: "INSERT",
+			ModelType: models.TokenTypeInsert, Literal: "INSERT"},
 		{Type: "INTO", Literal: "INTO"},
 		{Type: "IDENT", Literal: "orders"},
 		{Type: "(", Literal: "("},
@@ -494,7 +529,8 @@ func TestPoolContamination(t *testing.T) {
 
 	// Pattern C: CREATE TABLE
 	tokensC := []token.Token{
-		{Type: "CREATE", Literal: "CREATE"},
+		{Type: "CREATE",
+			ModelType: models.TokenTypeCreate, Literal: "CREATE"},
 		{Type: "TABLE", Literal: "TABLE"},
 		{Type: "IDENT", Literal: "products"},
 		{Type: "(", Literal: "("},
@@ -579,14 +615,16 @@ func TestPoolContamination(t *testing.T) {
 func TestPoolContamination_ErrorThenSuccess(t *testing.T) {
 	// Malformed SQL
 	badTokens := []token.Token{
-		{Type: "SELECT", Literal: "SELECT"},
+		{Type: "SELECT",
+			ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 		{Type: "FROM", Literal: "FROM"},
 		{Type: "WHERE", Literal: "WHERE"},
 	}
 
 	// Valid SQL
 	goodTokens := []token.Token{
-		{Type: "SELECT", Literal: "SELECT"},
+		{Type: "SELECT",
+			ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 		{Type: "IDENT", Literal: "id"},
 		{Type: "FROM", Literal: "FROM"},
 		{Type: "IDENT", Literal: "users"},
@@ -615,7 +653,8 @@ func TestPoolContamination_Concurrent(t *testing.T) {
 	patterns := [][]token.Token{
 		// SELECT
 		{
-			{Type: "SELECT", Literal: "SELECT"},
+			{Type: "SELECT",
+				ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 			{Type: "*", Literal: "*"},
 			{Type: "FROM", Literal: "FROM"},
 			{Type: "IDENT", Literal: "users"},
@@ -673,16 +712,16 @@ func TestPoolContamination_Concurrent(t *testing.T) {
 func TestContextCancellation_MidParse(t *testing.T) {
 	// Build a large token list to increase chance of mid-parse cancellation
 	var tokens []token.Token
-	tokens = append(tokens, token.Token{Type: "SELECT", Literal: "SELECT"})
+	tokens = append(tokens, token.Token{Type: "SELECT", ModelType: models.TokenTypeSelect, Literal: "SELECT"})
 	for i := 0; i < 100; i++ {
 		if i > 0 {
-			tokens = append(tokens, token.Token{Type: ",", Literal: ","})
+			tokens = append(tokens, token.Token{Type: ",", ModelType: models.TokenTypeComma, Literal: ","})
 		}
-		tokens = append(tokens, token.Token{Type: "IDENT", Literal: "col"})
+		tokens = append(tokens, token.Token{Type: "IDENT", ModelType: models.TokenTypeIdentifier, Literal: "col"})
 	}
 	tokens = append(tokens,
-		token.Token{Type: "FROM", Literal: "FROM"},
-		token.Token{Type: "IDENT", Literal: "big_table"},
+		token.Token{Type: "FROM", ModelType: models.TokenTypeFrom, Literal: "FROM"},
+		token.Token{Type: "IDENT", ModelType: models.TokenTypeIdentifier, Literal: "big_table"},
 	)
 
 	// Cancel context almost immediately

--- a/pkg/sql/parser/operators_test.go
+++ b/pkg/sql/parser/operators_test.go
@@ -12,7 +12,8 @@ import (
 func TestParser_BetweenExpression(t *testing.T) {
 	// SELECT * FROM products WHERE price BETWEEN 10 AND 100
 	tokens := []token.Token{
-		{Type: "SELECT", Literal: "SELECT"},
+		{Type: "SELECT",
+			ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 		{Type: "*", Literal: "*"},
 		{Type: "FROM", Literal: "FROM"},
 		{Type: "IDENT", Literal: "products"},
@@ -58,7 +59,8 @@ func TestParser_BetweenExpression(t *testing.T) {
 func TestParser_NotBetweenExpression(t *testing.T) {
 	// SELECT * FROM products WHERE price NOT BETWEEN 10 AND 100
 	tokens := []token.Token{
-		{Type: "SELECT", Literal: "SELECT"},
+		{Type: "SELECT",
+			ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 		{Type: "*", Literal: "*"},
 		{Type: "FROM", Literal: "FROM"},
 		{Type: "IDENT", Literal: "products"},
@@ -92,7 +94,8 @@ func TestParser_NotBetweenExpression(t *testing.T) {
 func TestParser_InExpression(t *testing.T) {
 	// SELECT * FROM orders WHERE status IN ('pending', 'processing', 'shipped')
 	tokens := []token.Token{
-		{Type: "SELECT", Literal: "SELECT"},
+		{Type: "SELECT",
+			ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 		{Type: "*", Literal: "*"},
 		{Type: "FROM", Literal: "FROM"},
 		{Type: "IDENT", Literal: "orders"},
@@ -136,7 +139,8 @@ func TestParser_InExpression(t *testing.T) {
 func TestParser_NotInExpression(t *testing.T) {
 	// SELECT * FROM orders WHERE status NOT IN ('cancelled')
 	tokens := []token.Token{
-		{Type: "SELECT", Literal: "SELECT"},
+		{Type: "SELECT",
+			ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 		{Type: "*", Literal: "*"},
 		{Type: "FROM", Literal: "FROM"},
 		{Type: "IDENT", Literal: "orders"},
@@ -170,7 +174,8 @@ func TestParser_NotInExpression(t *testing.T) {
 func TestParser_LikeExpression(t *testing.T) {
 	// SELECT * FROM users WHERE email LIKE '%@example.com'
 	tokens := []token.Token{
-		{Type: "SELECT", Literal: "SELECT"},
+		{Type: "SELECT",
+			ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 		{Type: "*", Literal: "*"},
 		{Type: "FROM", Literal: "FROM"},
 		{Type: "IDENT", Literal: "users"},
@@ -208,7 +213,8 @@ func TestParser_LikeExpression(t *testing.T) {
 func TestParser_NotLikeExpression(t *testing.T) {
 	// SELECT * FROM users WHERE name NOT LIKE 'Admin%'
 	tokens := []token.Token{
-		{Type: "SELECT", Literal: "SELECT"},
+		{Type: "SELECT",
+			ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 		{Type: "*", Literal: "*"},
 		{Type: "FROM", Literal: "FROM"},
 		{Type: "IDENT", Literal: "users"},
@@ -240,7 +246,8 @@ func TestParser_NotLikeExpression(t *testing.T) {
 func TestParser_IsNullExpression(t *testing.T) {
 	// SELECT * FROM customers WHERE deleted_at IS NULL
 	tokens := []token.Token{
-		{Type: "SELECT", Literal: "SELECT"},
+		{Type: "SELECT",
+			ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 		{Type: "*", Literal: "*"},
 		{Type: "FROM", Literal: "FROM"},
 		{Type: "IDENT", Literal: "customers"},
@@ -278,7 +285,8 @@ func TestParser_IsNullExpression(t *testing.T) {
 func TestParser_IsNotNullExpression(t *testing.T) {
 	// SELECT * FROM posts WHERE published_at IS NOT NULL
 	tokens := []token.Token{
-		{Type: "SELECT", Literal: "SELECT"},
+		{Type: "SELECT",
+			ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 		{Type: "*", Literal: "*"},
 		{Type: "FROM", Literal: "FROM"},
 		{Type: "IDENT", Literal: "posts"},
@@ -314,7 +322,8 @@ func TestParser_IsNotNullExpression(t *testing.T) {
 func TestParser_BetweenWithIdentifiers(t *testing.T) {
 	// SELECT * FROM events WHERE event_date BETWEEN start_date AND end_date
 	tokens := []token.Token{
-		{Type: "SELECT", Literal: "SELECT"},
+		{Type: "SELECT",
+			ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 		{Type: "*", Literal: "*"},
 		{Type: "FROM", Literal: "FROM"},
 		{Type: "IDENT", Literal: "events"},
@@ -355,7 +364,8 @@ func TestParser_BetweenWithIdentifiers(t *testing.T) {
 func TestParser_BetweenWithArithmeticExpressions(t *testing.T) {
 	// SELECT * FROM products WHERE price BETWEEN price * 0.9 AND price * 1.1
 	tokens := []token.Token{
-		{Type: "SELECT", Literal: "SELECT"},
+		{Type: "SELECT",
+			ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 		{Type: "*", Literal: "*"},
 		{Type: "FROM", Literal: "FROM"},
 		{Type: "IDENT", Literal: "products"},
@@ -406,7 +416,8 @@ func TestParser_BetweenWithArithmeticExpressions(t *testing.T) {
 func TestParser_BetweenWithAdditionSubtraction(t *testing.T) {
 	// SELECT * FROM orders WHERE total BETWEEN subtotal - 10 AND subtotal + 10
 	tokens := []token.Token{
-		{Type: "SELECT", Literal: "SELECT"},
+		{Type: "SELECT",
+			ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 		{Type: "*", Literal: "*"},
 		{Type: "FROM", Literal: "FROM"},
 		{Type: "IDENT", Literal: "orders"},
@@ -457,7 +468,8 @@ func TestParser_BetweenWithAdditionSubtraction(t *testing.T) {
 func TestParser_BetweenWithFunctionCallsAndArithmetic(t *testing.T) {
 	// SELECT * FROM orders WHERE amount BETWEEN MIN(price) AND MAX(price) * 2
 	tokens := []token.Token{
-		{Type: "SELECT", Literal: "SELECT"},
+		{Type: "SELECT",
+			ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 		{Type: "*", Literal: "*"},
 		{Type: "FROM", Literal: "FROM"},
 		{Type: "IDENT", Literal: "orders"},
@@ -509,7 +521,8 @@ func TestParser_BetweenWithFunctionCallsAndArithmetic(t *testing.T) {
 func TestParser_InWithNumbers(t *testing.T) {
 	// SELECT * FROM products WHERE category_id IN (1, 2, 3)
 	tokens := []token.Token{
-		{Type: "SELECT", Literal: "SELECT"},
+		{Type: "SELECT",
+			ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 		{Type: "*", Literal: "*"},
 		{Type: "FROM", Literal: "FROM"},
 		{Type: "IDENT", Literal: "products"},
@@ -558,7 +571,8 @@ func TestParser_InWithNumbers(t *testing.T) {
 func TestParser_TupleInExpression(t *testing.T) {
 	// SELECT * FROM orders WHERE (user_id, status) IN ((1, 'active'), (2, 'pending'))
 	tokens := []token.Token{
-		{Type: "SELECT", Literal: "SELECT"},
+		{Type: "SELECT",
+			ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 		{Type: "*", Literal: "*"},
 		{Type: "FROM", Literal: "FROM"},
 		{Type: "IDENT", Literal: "orders"},
@@ -637,7 +651,8 @@ func TestParser_TupleInExpression(t *testing.T) {
 func TestParser_TupleNotInExpression(t *testing.T) {
 	// SELECT * FROM orders WHERE (user_id, status) NOT IN ((1, 'cancelled'))
 	tokens := []token.Token{
-		{Type: "SELECT", Literal: "SELECT"},
+		{Type: "SELECT",
+			ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 		{Type: "*", Literal: "*"},
 		{Type: "FROM", Literal: "FROM"},
 		{Type: "IDENT", Literal: "orders"},
@@ -692,7 +707,8 @@ func TestParser_TupleNotInExpression(t *testing.T) {
 func TestParser_SimpleTupleExpression(t *testing.T) {
 	// SELECT (1, 2, 3)
 	tokens := []token.Token{
-		{Type: "SELECT", Literal: "SELECT"},
+		{Type: "SELECT",
+			ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 		{Type: "(", Literal: "("},
 		{Type: "INT", Literal: "1"},
 		{Type: ",", Literal: ","},
@@ -731,7 +747,8 @@ func TestParser_CombinedOperators(t *testing.T) {
 	// SELECT * FROM users WHERE age BETWEEN 18 AND 65 AND status IN ('active') AND name LIKE 'J%' AND deleted_at IS NULL
 	// This is a complex test combining all operators with AND
 	tokens := []token.Token{
-		{Type: "SELECT", Literal: "SELECT"},
+		{Type: "SELECT",
+			ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 		{Type: "*", Literal: "*"},
 		{Type: "FROM", Literal: "FROM"},
 		{Type: "IDENT", Literal: "users"},
@@ -783,7 +800,8 @@ func TestParser_OperatorErrors(t *testing.T) {
 		{
 			name: "BETWEEN without AND",
 			tokens: []token.Token{
-				{Type: "SELECT", Literal: "SELECT"},
+				{Type: "SELECT",
+					ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 				{Type: "*", Literal: "*"},
 				{Type: "FROM", Literal: "FROM"},
 				{Type: "IDENT", Literal: "t"},
@@ -797,7 +815,8 @@ func TestParser_OperatorErrors(t *testing.T) {
 		{
 			name: "IN without closing paren",
 			tokens: []token.Token{
-				{Type: "SELECT", Literal: "SELECT"},
+				{Type: "SELECT",
+					ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 				{Type: "*", Literal: "*"},
 				{Type: "FROM", Literal: "FROM"},
 				{Type: "IDENT", Literal: "t"},
@@ -812,7 +831,8 @@ func TestParser_OperatorErrors(t *testing.T) {
 		{
 			name: "IS without NULL",
 			tokens: []token.Token{
-				{Type: "SELECT", Literal: "SELECT"},
+				{Type: "SELECT",
+					ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 				{Type: "*", Literal: "*"},
 				{Type: "FROM", Literal: "FROM"},
 				{Type: "IDENT", Literal: "t"},
@@ -911,7 +931,8 @@ func TestParser_StringConcatenation(t *testing.T) {
 func TestParser_StringConcatWithColumns(t *testing.T) {
 	// SELECT first_name || ' ' || last_name FROM users
 	tokens := []token.Token{
-		{Type: "SELECT", Literal: "SELECT"},
+		{Type: "SELECT",
+			ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 		{Type: "IDENT", Literal: "first_name"},
 		{Type: "STRING_CONCAT", Literal: "||"},
 		{Type: "STRING", Literal: " "},
@@ -950,7 +971,8 @@ func TestParser_StringConcatWithColumns(t *testing.T) {
 func TestParser_StringConcatWithAlias(t *testing.T) {
 	// SELECT first_name || last_name AS fullname FROM users
 	tokens := []token.Token{
-		{Type: "SELECT", Literal: "SELECT"},
+		{Type: "SELECT",
+			ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 		{Type: "IDENT", Literal: "first_name"},
 		{Type: "STRING_CONCAT", Literal: "||"},
 		{Type: "IDENT", Literal: "last_name"},

--- a/pkg/sql/parser/parser_bench_test.go
+++ b/pkg/sql/parser/parser_bench_test.go
@@ -264,20 +264,20 @@ func BenchmarkParser_RecursionDepthCheck(b *testing.B) {
 			name: "ModerateNesting",
 			tokens: func() []token.Token {
 				// Build a moderately nested query (20 levels) - realistic usage
-				tokens := []token.Token{{Type: "SELECT", Literal: "SELECT"}}
+				tokens := []token.Token{{Type: "SELECT", ModelType: models.TokenTypeSelect, Literal: "SELECT"}}
 				for i := 0; i < 20; i++ {
 					tokens = append(tokens,
-						token.Token{Type: "IDENT", Literal: "func"},
-						token.Token{Type: "(", Literal: "("},
+						token.Token{Type: "IDENT", ModelType: models.TokenTypeIdentifier, Literal: "func"},
+						token.Token{Type: "(", ModelType: models.TokenTypeLParen, Literal: "("},
 					)
 				}
-				tokens = append(tokens, token.Token{Type: "IDENT", Literal: "x"})
+				tokens = append(tokens, token.Token{Type: "IDENT", ModelType: models.TokenTypeIdentifier, Literal: "x"})
 				for i := 0; i < 20; i++ {
-					tokens = append(tokens, token.Token{Type: ")", Literal: ")"})
+					tokens = append(tokens, token.Token{Type: ")", ModelType: models.TokenTypeRParen, Literal: ")"})
 				}
 				tokens = append(tokens,
-					token.Token{Type: "FROM", Literal: "FROM"},
-					token.Token{Type: "IDENT", Literal: "t"},
+					token.Token{Type: "FROM", ModelType: models.TokenTypeFrom, Literal: "FROM"},
+					token.Token{Type: "IDENT", ModelType: models.TokenTypeIdentifier, Literal: "t"},
 				)
 				return tokens
 			}(),
@@ -287,20 +287,20 @@ func BenchmarkParser_RecursionDepthCheck(b *testing.B) {
 			tokens: func() []token.Token {
 				// Build a deeply nested query (80 levels) - approaching limit
 				// Tests performance near MaxRecursionDepth (100 levels)
-				tokens := []token.Token{{Type: "SELECT", Literal: "SELECT"}}
+				tokens := []token.Token{{Type: "SELECT", ModelType: models.TokenTypeSelect, Literal: "SELECT"}}
 				for i := 0; i < 80; i++ {
 					tokens = append(tokens,
-						token.Token{Type: "IDENT", Literal: "func"},
-						token.Token{Type: "(", Literal: "("},
+						token.Token{Type: "IDENT", ModelType: models.TokenTypeIdentifier, Literal: "func"},
+						token.Token{Type: "(", ModelType: models.TokenTypeLParen, Literal: "("},
 					)
 				}
-				tokens = append(tokens, token.Token{Type: "IDENT", Literal: "x"})
+				tokens = append(tokens, token.Token{Type: "IDENT", ModelType: models.TokenTypeIdentifier, Literal: "x"})
 				for i := 0; i < 80; i++ {
-					tokens = append(tokens, token.Token{Type: ")", Literal: ")"})
+					tokens = append(tokens, token.Token{Type: ")", ModelType: models.TokenTypeRParen, Literal: ")"})
 				}
 				tokens = append(tokens,
-					token.Token{Type: "FROM", Literal: "FROM"},
-					token.Token{Type: "IDENT", Literal: "t"},
+					token.Token{Type: "FROM", ModelType: models.TokenTypeFrom, Literal: "FROM"},
+					token.Token{Type: "IDENT", ModelType: models.TokenTypeIdentifier, Literal: "t"},
 				)
 				return tokens
 			}(),
@@ -310,20 +310,20 @@ func BenchmarkParser_RecursionDepthCheck(b *testing.B) {
 			tokens: func() []token.Token {
 				// Build a very deeply nested query (90 levels) - near limit threshold
 				// Tests performance at 90% of MaxRecursionDepth (100 levels)
-				tokens := []token.Token{{Type: "SELECT", Literal: "SELECT"}}
+				tokens := []token.Token{{Type: "SELECT", ModelType: models.TokenTypeSelect, Literal: "SELECT"}}
 				for i := 0; i < 90; i++ {
 					tokens = append(tokens,
-						token.Token{Type: "IDENT", Literal: "func"},
-						token.Token{Type: "(", Literal: "("},
+						token.Token{Type: "IDENT", ModelType: models.TokenTypeIdentifier, Literal: "func"},
+						token.Token{Type: "(", ModelType: models.TokenTypeLParen, Literal: "("},
 					)
 				}
-				tokens = append(tokens, token.Token{Type: "IDENT", Literal: "x"})
+				tokens = append(tokens, token.Token{Type: "IDENT", ModelType: models.TokenTypeIdentifier, Literal: "x"})
 				for i := 0; i < 90; i++ {
-					tokens = append(tokens, token.Token{Type: ")", Literal: ")"})
+					tokens = append(tokens, token.Token{Type: ")", ModelType: models.TokenTypeRParen, Literal: ")"})
 				}
 				tokens = append(tokens,
-					token.Token{Type: "FROM", Literal: "FROM"},
-					token.Token{Type: "IDENT", Literal: "t"},
+					token.Token{Type: "FROM", ModelType: models.TokenTypeFrom, Literal: "FROM"},
+					token.Token{Type: "IDENT", ModelType: models.TokenTypeIdentifier, Literal: "t"},
 				)
 				return tokens
 			}(),

--- a/pkg/sql/parser/parser_coverage_test.go
+++ b/pkg/sql/parser/parser_coverage_test.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"github.com/ajitpratap0/GoSQLX/pkg/models"
 	"testing"
 
 	"github.com/ajitpratap0/GoSQLX/pkg/sql/token"
@@ -20,7 +21,8 @@ func TestParser_AlterTable(t *testing.T) {
 		{
 			name: "ALTER TABLE ADD COLUMN",
 			tokens: []token.Token{
-				{Type: "ALTER", Literal: "ALTER"},
+				{Type: "ALTER",
+					ModelType: models.TokenTypeAlter, Literal: "ALTER"},
 				{Type: "TABLE", Literal: "TABLE"},
 				{Type: "IDENT", Literal: "users"},
 				{Type: "ADD", Literal: "ADD"},
@@ -33,7 +35,8 @@ func TestParser_AlterTable(t *testing.T) {
 		{
 			name: "ALTER TABLE DROP COLUMN",
 			tokens: []token.Token{
-				{Type: "ALTER", Literal: "ALTER"},
+				{Type: "ALTER",
+					ModelType: models.TokenTypeAlter, Literal: "ALTER"},
 				{Type: "TABLE", Literal: "TABLE"},
 				{Type: "IDENT", Literal: "employees"},
 				{Type: "DROP", Literal: "DROP"},
@@ -45,7 +48,8 @@ func TestParser_AlterTable(t *testing.T) {
 		{
 			name: "ALTER TABLE RENAME",
 			tokens: []token.Token{
-				{Type: "ALTER", Literal: "ALTER"},
+				{Type: "ALTER",
+					ModelType: models.TokenTypeAlter, Literal: "ALTER"},
 				{Type: "TABLE", Literal: "TABLE"},
 				{Type: "IDENT", Literal: "old_name"},
 				{Type: "RENAME", Literal: "RENAME"},
@@ -82,7 +86,8 @@ func TestParser_StringLiterals(t *testing.T) {
 		{
 			name: "SELECT with single-quoted string",
 			tokens: []token.Token{
-				{Type: "SELECT", Literal: "SELECT"},
+				{Type: "SELECT",
+					ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 				{Type: "STRING", Literal: "hello world"},
 				{Type: "FROM", Literal: "FROM"},
 				{Type: "IDENT", Literal: "messages"},
@@ -92,7 +97,8 @@ func TestParser_StringLiterals(t *testing.T) {
 		{
 			name: "INSERT with string literal",
 			tokens: []token.Token{
-				{Type: "INSERT", Literal: "INSERT"},
+				{Type: "INSERT",
+					ModelType: models.TokenTypeInsert, Literal: "INSERT"},
 				{Type: "INTO", Literal: "INTO"},
 				{Type: "IDENT", Literal: "users"},
 				{Type: "(", Literal: "("},
@@ -108,7 +114,8 @@ func TestParser_StringLiterals(t *testing.T) {
 		{
 			name: "WHERE clause with string comparison",
 			tokens: []token.Token{
-				{Type: "SELECT", Literal: "SELECT"},
+				{Type: "SELECT",
+					ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 				{Type: "*", Literal: "*"},
 				{Type: "FROM", Literal: "FROM"},
 				{Type: "IDENT", Literal: "users"},
@@ -145,7 +152,8 @@ func TestParser_WindowFrameBounds(t *testing.T) {
 		{
 			name: "ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW",
 			tokens: []token.Token{
-				{Type: "SELECT", Literal: "SELECT"},
+				{Type: "SELECT",
+					ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 				{Type: "IDENT", Literal: "SUM"},
 				{Type: "(", Literal: "("},
 				{Type: "IDENT", Literal: "amount"},
@@ -171,7 +179,8 @@ func TestParser_WindowFrameBounds(t *testing.T) {
 		{
 			name: "RANGE BETWEEN N PRECEDING AND N FOLLOWING",
 			tokens: []token.Token{
-				{Type: "SELECT", Literal: "SELECT"},
+				{Type: "SELECT",
+					ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 				{Type: "IDENT", Literal: "AVG"},
 				{Type: "(", Literal: "("},
 				{Type: "IDENT", Literal: "price"},
@@ -197,7 +206,8 @@ func TestParser_WindowFrameBounds(t *testing.T) {
 		{
 			name: "ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING",
 			tokens: []token.Token{
-				{Type: "SELECT", Literal: "SELECT"},
+				{Type: "SELECT",
+					ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 				{Type: "IDENT", Literal: "COUNT"},
 				{Type: "(", Literal: "("},
 				{Type: "*", Literal: "*"},
@@ -223,7 +233,8 @@ func TestParser_WindowFrameBounds(t *testing.T) {
 		{
 			name: "ROWS N PRECEDING (no AND clause)",
 			tokens: []token.Token{
-				{Type: "SELECT", Literal: "SELECT"},
+				{Type: "SELECT",
+					ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 				{Type: "IDENT", Literal: "SUM"},
 				{Type: "(", Literal: "("},
 				{Type: "IDENT", Literal: "value"},
@@ -269,7 +280,8 @@ func TestParser_ExpressionEdgeCases(t *testing.T) {
 		{
 			name: "nested parenthesized expressions",
 			tokens: []token.Token{
-				{Type: "SELECT", Literal: "SELECT"},
+				{Type: "SELECT",
+					ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 				{Type: "(", Literal: "("},
 				{Type: "(", Literal: "("},
 				{Type: "IDENT", Literal: "a"},
@@ -287,7 +299,8 @@ func TestParser_ExpressionEdgeCases(t *testing.T) {
 		{
 			name: "complex boolean expression with NOT",
 			tokens: []token.Token{
-				{Type: "SELECT", Literal: "SELECT"},
+				{Type: "SELECT",
+					ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 				{Type: "*", Literal: "*"},
 				{Type: "FROM", Literal: "FROM"},
 				{Type: "IDENT", Literal: "users"},
@@ -308,7 +321,8 @@ func TestParser_ExpressionEdgeCases(t *testing.T) {
 		{
 			name: "BETWEEN expression",
 			tokens: []token.Token{
-				{Type: "SELECT", Literal: "SELECT"},
+				{Type: "SELECT",
+					ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 				{Type: "*", Literal: "*"},
 				{Type: "FROM", Literal: "FROM"},
 				{Type: "IDENT", Literal: "products"},
@@ -324,7 +338,8 @@ func TestParser_ExpressionEdgeCases(t *testing.T) {
 		{
 			name: "IN expression with list",
 			tokens: []token.Token{
-				{Type: "SELECT", Literal: "SELECT"},
+				{Type: "SELECT",
+					ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 				{Type: "*", Literal: "*"},
 				{Type: "FROM", Literal: "FROM"},
 				{Type: "IDENT", Literal: "orders"},
@@ -344,7 +359,8 @@ func TestParser_ExpressionEdgeCases(t *testing.T) {
 		{
 			name: "LIKE expression",
 			tokens: []token.Token{
-				{Type: "SELECT", Literal: "SELECT"},
+				{Type: "SELECT",
+					ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 				{Type: "*", Literal: "*"},
 				{Type: "FROM", Literal: "FROM"},
 				{Type: "IDENT", Literal: "users"},
@@ -358,7 +374,8 @@ func TestParser_ExpressionEdgeCases(t *testing.T) {
 		{
 			name: "IS NULL expression",
 			tokens: []token.Token{
-				{Type: "SELECT", Literal: "SELECT"},
+				{Type: "SELECT",
+					ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 				{Type: "*", Literal: "*"},
 				{Type: "FROM", Literal: "FROM"},
 				{Type: "IDENT", Literal: "customers"},
@@ -372,7 +389,8 @@ func TestParser_ExpressionEdgeCases(t *testing.T) {
 		{
 			name: "IS NOT NULL expression",
 			tokens: []token.Token{
-				{Type: "SELECT", Literal: "SELECT"},
+				{Type: "SELECT",
+					ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 				{Type: "*", Literal: "*"},
 				{Type: "FROM", Literal: "FROM"},
 				{Type: "IDENT", Literal: "posts"},
@@ -387,7 +405,8 @@ func TestParser_ExpressionEdgeCases(t *testing.T) {
 		{
 			name: "arithmetic expression with multiple operators",
 			tokens: []token.Token{
-				{Type: "SELECT", Literal: "SELECT"},
+				{Type: "SELECT",
+					ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 				{Type: "IDENT", Literal: "a"},
 				{Type: "+", Literal: "+"},
 				{Type: "IDENT", Literal: "b"},
@@ -428,7 +447,8 @@ func TestParser_ErrorRecovery(t *testing.T) {
 		{
 			name: "missing FROM keyword",
 			tokens: []token.Token{
-				{Type: "SELECT", Literal: "SELECT"},
+				{Type: "SELECT",
+					ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 				{Type: "*", Literal: "*"},
 				{Type: "IDENT", Literal: "users"}, // Missing FROM
 			},
@@ -437,7 +457,8 @@ func TestParser_ErrorRecovery(t *testing.T) {
 		{
 			name: "missing table name after FROM",
 			tokens: []token.Token{
-				{Type: "SELECT", Literal: "SELECT"},
+				{Type: "SELECT",
+					ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 				{Type: "*", Literal: "*"},
 				{Type: "FROM", Literal: "FROM"},
 				// Missing table name - parser will hit EOF
@@ -447,7 +468,8 @@ func TestParser_ErrorRecovery(t *testing.T) {
 		{
 			name: "missing closing parenthesis in function",
 			tokens: []token.Token{
-				{Type: "SELECT", Literal: "SELECT"},
+				{Type: "SELECT",
+					ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 				{Type: "IDENT", Literal: "COUNT"},
 				{Type: "(", Literal: "("},
 				{Type: "*", Literal: "*"},
@@ -460,7 +482,8 @@ func TestParser_ErrorRecovery(t *testing.T) {
 		{
 			name: "incomplete WHERE clause",
 			tokens: []token.Token{
-				{Type: "SELECT", Literal: "SELECT"},
+				{Type: "SELECT",
+					ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 				{Type: "*", Literal: "*"},
 				{Type: "FROM", Literal: "FROM"},
 				{Type: "IDENT", Literal: "users"},
@@ -472,7 +495,8 @@ func TestParser_ErrorRecovery(t *testing.T) {
 		{
 			name: "missing SET in UPDATE",
 			tokens: []token.Token{
-				{Type: "UPDATE", Literal: "UPDATE"},
+				{Type: "UPDATE",
+					ModelType: models.TokenTypeUpdate, Literal: "UPDATE"},
 				{Type: "IDENT", Literal: "users"},
 				{Type: "WHERE", Literal: "WHERE"}, // Missing SET
 				{Type: "IDENT", Literal: "id"},
@@ -484,7 +508,8 @@ func TestParser_ErrorRecovery(t *testing.T) {
 		{
 			name: "invalid JOIN syntax - missing table",
 			tokens: []token.Token{
-				{Type: "SELECT", Literal: "SELECT"},
+				{Type: "SELECT",
+					ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 				{Type: "*", Literal: "*"},
 				{Type: "FROM", Literal: "FROM"},
 				{Type: "IDENT", Literal: "users"},
@@ -500,7 +525,8 @@ func TestParser_ErrorRecovery(t *testing.T) {
 		{
 			name: "missing comparison operator in WHERE",
 			tokens: []token.Token{
-				{Type: "SELECT", Literal: "SELECT"},
+				{Type: "SELECT",
+					ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 				{Type: "*", Literal: "*"},
 				{Type: "FROM", Literal: "FROM"},
 				{Type: "IDENT", Literal: "users"},
@@ -514,7 +540,8 @@ func TestParser_ErrorRecovery(t *testing.T) {
 		{
 			name: "invalid ORDER BY syntax - missing BY",
 			tokens: []token.Token{
-				{Type: "SELECT", Literal: "SELECT"},
+				{Type: "SELECT",
+					ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 				{Type: "*", Literal: "*"},
 				{Type: "FROM", Literal: "FROM"},
 				{Type: "IDENT", Literal: "users"},
@@ -540,7 +567,8 @@ func TestParser_ErrorRecovery(t *testing.T) {
 			// Verify parser is still in valid state by creating a new parser for a simple query
 			if err != nil {
 				simpleTokens := []token.Token{
-					{Type: "SELECT", Literal: "SELECT"},
+					{Type: "SELECT",
+						ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 					{Type: "*", Literal: "*"},
 					{Type: "FROM", Literal: "FROM"},
 					{Type: "IDENT", Literal: "test"},
@@ -568,7 +596,8 @@ func TestParser_CTEEdgeCases(t *testing.T) {
 		{
 			name: "CTE with INSERT statement",
 			tokens: []token.Token{
-				{Type: "WITH", Literal: "WITH"},
+				{Type: "WITH",
+					ModelType: models.TokenTypeWith, Literal: "WITH"},
 				{Type: "IDENT", Literal: "new_users"},
 				{Type: "AS", Literal: "AS"},
 				{Type: "(", Literal: "("},
@@ -594,7 +623,8 @@ func TestParser_CTEEdgeCases(t *testing.T) {
 		{
 			name: "CTE with UPDATE statement",
 			tokens: []token.Token{
-				{Type: "WITH", Literal: "WITH"},
+				{Type: "WITH",
+					ModelType: models.TokenTypeWith, Literal: "WITH"},
 				{Type: "IDENT", Literal: "active"},
 				{Type: "AS", Literal: "AS"},
 				{Type: "(", Literal: "("},
@@ -628,7 +658,8 @@ func TestParser_CTEEdgeCases(t *testing.T) {
 		{
 			name: "CTE with DELETE statement",
 			tokens: []token.Token{
-				{Type: "WITH", Literal: "WITH"},
+				{Type: "WITH",
+					ModelType: models.TokenTypeWith, Literal: "WITH"},
 				{Type: "IDENT", Literal: "old_records"},
 				{Type: "AS", Literal: "AS"},
 				{Type: "(", Literal: "("},
@@ -682,7 +713,8 @@ func TestParser_SetOperationPrecedence(t *testing.T) {
 		{
 			name: "UNION ALL with multiple queries",
 			tokens: []token.Token{
-				{Type: "SELECT", Literal: "SELECT"},
+				{Type: "SELECT",
+					ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 				{Type: "INT", Literal: "1"},
 				{Type: "UNION", Literal: "UNION"},
 				{Type: "ALL", Literal: "ALL"},
@@ -698,7 +730,8 @@ func TestParser_SetOperationPrecedence(t *testing.T) {
 		{
 			name: "EXCEPT and INTERSECT combination",
 			tokens: []token.Token{
-				{Type: "SELECT", Literal: "SELECT"},
+				{Type: "SELECT",
+					ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 				{Type: "*", Literal: "*"},
 				{Type: "FROM", Literal: "FROM"},
 				{Type: "IDENT", Literal: "a"},
@@ -718,7 +751,8 @@ func TestParser_SetOperationPrecedence(t *testing.T) {
 		{
 			name: "parenthesized UNION",
 			tokens: []token.Token{
-				{Type: "(", Literal: "("},
+				{Type: "(",
+					ModelType: models.TokenTypeLParen, Literal: "("},
 				{Type: "SELECT", Literal: "SELECT"},
 				{Type: "INT", Literal: "1"},
 				{Type: "UNION", Literal: "UNION"},
@@ -759,7 +793,8 @@ func TestParser_TableDrivenComplexScenarios(t *testing.T) {
 			name: "subquery in WHERE clause",
 			desc: "Tests subquery handling in WHERE predicates",
 			tokens: []token.Token{
-				{Type: "SELECT", Literal: "SELECT"},
+				{Type: "SELECT",
+					ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 				{Type: "*", Literal: "*"},
 				{Type: "FROM", Literal: "FROM"},
 				{Type: "IDENT", Literal: "orders"},
@@ -783,7 +818,8 @@ func TestParser_TableDrivenComplexScenarios(t *testing.T) {
 			name: "CASE expression in SELECT",
 			desc: "Tests CASE WHEN THEN ELSE END expression",
 			tokens: []token.Token{
-				{Type: "SELECT", Literal: "SELECT"},
+				{Type: "SELECT",
+					ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 				{Type: "CASE", Literal: "CASE"},
 				{Type: "WHEN", Literal: "WHEN"},
 				{Type: "IDENT", Literal: "age"},
@@ -803,7 +839,8 @@ func TestParser_TableDrivenComplexScenarios(t *testing.T) {
 			name: "DISTINCT with aggregate",
 			desc: "Tests DISTINCT keyword with aggregation",
 			tokens: []token.Token{
-				{Type: "SELECT", Literal: "SELECT"},
+				{Type: "SELECT",
+					ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 				{Type: "COUNT", Literal: "COUNT"},
 				{Type: "(", Literal: "("},
 				{Type: "DISTINCT", Literal: "DISTINCT"},
@@ -818,7 +855,8 @@ func TestParser_TableDrivenComplexScenarios(t *testing.T) {
 			name: "GROUP BY with HAVING",
 			desc: "Tests GROUP BY clause with HAVING filter",
 			tokens: []token.Token{
-				{Type: "SELECT", Literal: "SELECT"},
+				{Type: "SELECT",
+					ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 				{Type: "IDENT", Literal: "category"},
 				{Type: ",", Literal: ","},
 				{Type: "COUNT", Literal: "COUNT"},
@@ -868,7 +906,8 @@ func TestParser_GroupingOperations(t *testing.T) {
 			name: "ROLLUP with two columns",
 			desc: "GROUP BY ROLLUP(a, b)",
 			tokens: []token.Token{
-				{Type: "SELECT", Literal: "SELECT"},
+				{Type: "SELECT",
+					ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 				{Type: "IDENT", Literal: "a"},
 				{Type: ",", Literal: ","},
 				{Type: "IDENT", Literal: "b"},
@@ -889,7 +928,8 @@ func TestParser_GroupingOperations(t *testing.T) {
 			name: "Empty ROLLUP fails",
 			desc: "GROUP BY ROLLUP() should fail",
 			tokens: []token.Token{
-				{Type: "SELECT", Literal: "SELECT"},
+				{Type: "SELECT",
+					ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 				{Type: "IDENT", Literal: "a"},
 				{Type: "FROM", Literal: "FROM"},
 				{Type: "IDENT", Literal: "t"},
@@ -906,7 +946,8 @@ func TestParser_GroupingOperations(t *testing.T) {
 			name: "CUBE with two columns",
 			desc: "GROUP BY CUBE(a, b)",
 			tokens: []token.Token{
-				{Type: "SELECT", Literal: "SELECT"},
+				{Type: "SELECT",
+					ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 				{Type: "IDENT", Literal: "a"},
 				{Type: "FROM", Literal: "FROM"},
 				{Type: "IDENT", Literal: "t"},
@@ -925,7 +966,8 @@ func TestParser_GroupingOperations(t *testing.T) {
 			name: "Empty CUBE fails",
 			desc: "GROUP BY CUBE() should fail",
 			tokens: []token.Token{
-				{Type: "SELECT", Literal: "SELECT"},
+				{Type: "SELECT",
+					ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 				{Type: "IDENT", Literal: "a"},
 				{Type: "FROM", Literal: "FROM"},
 				{Type: "IDENT", Literal: "t"},
@@ -942,7 +984,8 @@ func TestParser_GroupingOperations(t *testing.T) {
 			name: "GROUPING SETS with multiple sets",
 			desc: "GROUP BY GROUPING SETS((a, b), (a), ())",
 			tokens: []token.Token{
-				{Type: "SELECT", Literal: "SELECT"},
+				{Type: "SELECT",
+					ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 				{Type: "IDENT", Literal: "a"},
 				{Type: "FROM", Literal: "FROM"},
 				{Type: "IDENT", Literal: "t"},
@@ -970,7 +1013,8 @@ func TestParser_GroupingOperations(t *testing.T) {
 			name: "GROUPING SETS with only empty set",
 			desc: "GROUP BY GROUPING SETS(()) is valid for grand total",
 			tokens: []token.Token{
-				{Type: "SELECT", Literal: "SELECT"},
+				{Type: "SELECT",
+					ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 				{Type: "IDENT", Literal: "total"},
 				{Type: "FROM", Literal: "FROM"},
 				{Type: "IDENT", Literal: "t"},
@@ -989,7 +1033,8 @@ func TestParser_GroupingOperations(t *testing.T) {
 			name: "Mixed regular column and ROLLUP",
 			desc: "GROUP BY a, ROLLUP(b, c)",
 			tokens: []token.Token{
-				{Type: "SELECT", Literal: "SELECT"},
+				{Type: "SELECT",
+					ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 				{Type: "IDENT", Literal: "a"},
 				{Type: "FROM", Literal: "FROM"},
 				{Type: "IDENT", Literal: "t"},

--- a/pkg/sql/parser/parser_test.go
+++ b/pkg/sql/parser/parser_test.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"github.com/ajitpratap0/GoSQLX/pkg/models"
 	"testing"
 
 	"github.com/ajitpratap0/GoSQLX/pkg/sql/ast"
@@ -9,7 +10,8 @@ import (
 
 func TestParserSimpleSelect(t *testing.T) {
 	tokens := []token.Token{
-		{Type: "SELECT", Literal: "SELECT"},
+		{Type: "SELECT",
+			ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 		{Type: "IDENT", Literal: "id"},
 		{Type: ",", Literal: ","},
 		{Type: "IDENT", Literal: "name"},
@@ -45,7 +47,8 @@ func TestParserSimpleSelect(t *testing.T) {
 
 func TestParserComplexSelect(t *testing.T) {
 	tokens := []token.Token{
-		{Type: "SELECT", Literal: "SELECT"},
+		{Type: "SELECT",
+			ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 		{Type: "IDENT", Literal: "u"},
 		{Type: ".", Literal: "."},
 		{Type: "IDENT", Literal: "id"},
@@ -123,7 +126,8 @@ func TestParserComplexSelect(t *testing.T) {
 
 func TestParserInsert(t *testing.T) {
 	tokens := []token.Token{
-		{Type: "INSERT", Literal: "INSERT"},
+		{Type: "INSERT",
+			ModelType: models.TokenTypeInsert, Literal: "INSERT"},
 		{Type: "INTO", Literal: "INTO"},
 		{Type: "IDENT", Literal: "users"},
 		{Type: "(", Literal: "("},
@@ -171,7 +175,8 @@ func TestParserInsert(t *testing.T) {
 
 func TestParserUpdate(t *testing.T) {
 	tokens := []token.Token{
-		{Type: "UPDATE", Literal: "UPDATE"},
+		{Type: "UPDATE",
+			ModelType: models.TokenTypeUpdate, Literal: "UPDATE"},
 		{Type: "IDENT", Literal: "users"},
 		{Type: "SET", Literal: "SET"},
 		{Type: "IDENT", Literal: "active"},
@@ -211,7 +216,8 @@ func TestParserUpdate(t *testing.T) {
 
 func TestParserDelete(t *testing.T) {
 	tokens := []token.Token{
-		{Type: "DELETE", Literal: "DELETE"},
+		{Type: "DELETE",
+			ModelType: models.TokenTypeDelete, Literal: "DELETE"},
 		{Type: "FROM", Literal: "FROM"},
 		{Type: "IDENT", Literal: "users"},
 		{Type: "WHERE", Literal: "WHERE"},
@@ -245,7 +251,8 @@ func TestParserDelete(t *testing.T) {
 
 func TestParserParallel(t *testing.T) {
 	tokens := []token.Token{
-		{Type: "SELECT", Literal: "SELECT"},
+		{Type: "SELECT",
+			ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 		{Type: "IDENT", Literal: "id"},
 		{Type: "FROM", Literal: "FROM"},
 		{Type: "IDENT", Literal: "users"},
@@ -273,7 +280,8 @@ func TestParserReuse(t *testing.T) {
 
 	queries := [][]token.Token{
 		{ // Simple SELECT
-			{Type: "SELECT", Literal: "SELECT"},
+			{Type: "SELECT",
+				ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 			{Type: "IDENT", Literal: "id"},
 			{Type: "FROM", Literal: "FROM"},
 			{Type: "IDENT", Literal: "users"},
@@ -319,28 +327,29 @@ func TestRecursionDepthLimit_DeeplyNestedFunctionCalls(t *testing.T) {
 
 	// Build tokens for: SELECT f1(f2(f3(...f150(x)...))) FROM t
 	tokens := []token.Token{
-		{Type: "SELECT", Literal: "SELECT"},
+		{Type: "SELECT",
+			ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 	}
 
 	// Add opening function calls
 	for i := 0; i < 150; i++ {
 		tokens = append(tokens,
-			token.Token{Type: "IDENT", Literal: "func"},
-			token.Token{Type: "(", Literal: "("},
+			token.Token{Type: "IDENT", ModelType: models.TokenTypeIdentifier, Literal: "func"},
+			token.Token{Type: "(", ModelType: models.TokenTypeLParen, Literal: "("},
 		)
 	}
 
 	// Add innermost argument
-	tokens = append(tokens, token.Token{Type: "IDENT", Literal: "x"})
+	tokens = append(tokens, token.Token{Type: "IDENT", ModelType: models.TokenTypeIdentifier, Literal: "x"})
 
 	// Add closing parentheses
 	for i := 0; i < 150; i++ {
-		tokens = append(tokens, token.Token{Type: ")", Literal: ")"})
+		tokens = append(tokens, token.Token{Type: ")", ModelType: models.TokenTypeRParen, Literal: ")"})
 	}
 
 	tokens = append(tokens,
-		token.Token{Type: "FROM", Literal: "FROM"},
-		token.Token{Type: "IDENT", Literal: "t"},
+		token.Token{Type: "FROM", ModelType: models.TokenTypeFrom, Literal: "FROM"},
+		token.Token{Type: "IDENT", ModelType: models.TokenTypeIdentifier, Literal: "t"},
 	)
 
 	_, err := parser.Parse(tokens)
@@ -364,32 +373,32 @@ func TestRecursionDepthLimit_DeeplyNestedCTEs(t *testing.T) {
 	// Add nested WITH clauses (150 levels deep)
 	for i := 0; i < 150; i++ {
 		tokens = append(tokens,
-			token.Token{Type: "WITH", Literal: "WITH"},
-			token.Token{Type: "IDENT", Literal: "cte"},
-			token.Token{Type: "AS", Literal: "AS"},
-			token.Token{Type: "(", Literal: "("},
+			token.Token{Type: "WITH", ModelType: models.TokenTypeWith, Literal: "WITH"},
+			token.Token{Type: "IDENT", ModelType: models.TokenTypeIdentifier, Literal: "cte"},
+			token.Token{Type: "AS", ModelType: models.TokenTypeAs, Literal: "AS"},
+			token.Token{Type: "(", ModelType: models.TokenTypeLParen, Literal: "("},
 		)
 	}
 
 	// Add innermost SELECT
 	tokens = append(tokens,
-		token.Token{Type: "SELECT", Literal: "SELECT"},
-		token.Token{Type: "IDENT", Literal: "x"},
-		token.Token{Type: "FROM", Literal: "FROM"},
-		token.Token{Type: "IDENT", Literal: "t"},
+		token.Token{Type: "SELECT", ModelType: models.TokenTypeSelect, Literal: "SELECT"},
+		token.Token{Type: "IDENT", ModelType: models.TokenTypeIdentifier, Literal: "x"},
+		token.Token{Type: "FROM", ModelType: models.TokenTypeFrom, Literal: "FROM"},
+		token.Token{Type: "IDENT", ModelType: models.TokenTypeIdentifier, Literal: "t"},
 	)
 
 	// Close all CTEs
 	for i := 0; i < 150; i++ {
-		tokens = append(tokens, token.Token{Type: ")", Literal: ")"})
+		tokens = append(tokens, token.Token{Type: ")", ModelType: models.TokenTypeRParen, Literal: ")"})
 	}
 
 	// Add final SELECT
 	tokens = append(tokens,
-		token.Token{Type: "SELECT", Literal: "SELECT"},
-		token.Token{Type: "*", Literal: "*"},
-		token.Token{Type: "FROM", Literal: "FROM"},
-		token.Token{Type: "IDENT", Literal: "cte"},
+		token.Token{Type: "SELECT", ModelType: models.TokenTypeSelect, Literal: "SELECT"},
+		token.Token{Type: "*", ModelType: models.TokenTypeAsterisk, Literal: "*"},
+		token.Token{Type: "FROM", ModelType: models.TokenTypeFrom, Literal: "FROM"},
+		token.Token{Type: "IDENT", ModelType: models.TokenTypeIdentifier, Literal: "cte"},
 	)
 
 	_, err := parser.Parse(tokens)
@@ -408,28 +417,29 @@ func TestRecursionDepthLimit_DepthResetAfterError(t *testing.T) {
 
 	// First, parse a query with deeply nested function calls that exceeds the limit (150 levels)
 	deepTokens := []token.Token{
-		{Type: "SELECT", Literal: "SELECT"},
+		{Type: "SELECT",
+			ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 	}
 
 	// Add opening function calls
 	for i := 0; i < 150; i++ {
 		deepTokens = append(deepTokens,
-			token.Token{Type: "IDENT", Literal: "func"},
-			token.Token{Type: "(", Literal: "("},
+			token.Token{Type: "IDENT", ModelType: models.TokenTypeIdentifier, Literal: "func"},
+			token.Token{Type: "(", ModelType: models.TokenTypeLParen, Literal: "("},
 		)
 	}
 
 	// Add innermost argument
-	deepTokens = append(deepTokens, token.Token{Type: "IDENT", Literal: "x"})
+	deepTokens = append(deepTokens, token.Token{Type: "IDENT", ModelType: models.TokenTypeIdentifier, Literal: "x"})
 
 	// Add closing parentheses
 	for i := 0; i < 150; i++ {
-		deepTokens = append(deepTokens, token.Token{Type: ")", Literal: ")"})
+		deepTokens = append(deepTokens, token.Token{Type: ")", ModelType: models.TokenTypeRParen, Literal: ")"})
 	}
 
 	deepTokens = append(deepTokens,
-		token.Token{Type: "FROM", Literal: "FROM"},
-		token.Token{Type: "IDENT", Literal: "t"},
+		token.Token{Type: "FROM", ModelType: models.TokenTypeFrom, Literal: "FROM"},
+		token.Token{Type: "IDENT", ModelType: models.TokenTypeIdentifier, Literal: "t"},
 	)
 
 	_, err := parser.Parse(deepTokens)
@@ -439,7 +449,8 @@ func TestRecursionDepthLimit_DepthResetAfterError(t *testing.T) {
 
 	// Now parse a simple query - it should succeed, proving depth was reset
 	simpleTokens := []token.Token{
-		{Type: "SELECT", Literal: "SELECT"},
+		{Type: "SELECT",
+			ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 		{Type: "IDENT", Literal: "id"},
 		{Type: "FROM", Literal: "FROM"},
 		{Type: "IDENT", Literal: "users"},
@@ -461,7 +472,8 @@ func TestRecursionDepthLimit_RecursiveCTELimit(t *testing.T) {
 
 	// Build a simple recursive CTE - this should work
 	tokens := []token.Token{
-		{Type: "WITH", Literal: "WITH"},
+		{Type: "WITH",
+			ModelType: models.TokenTypeWith, Literal: "WITH"},
 		{Type: "RECURSIVE", Literal: "RECURSIVE"},
 		{Type: "IDENT", Literal: "cte"},
 		{Type: "AS", Literal: "AS"},
@@ -493,7 +505,8 @@ func TestRecursionDepthLimit_ComplexWindowFunctions(t *testing.T) {
 
 	// Test a reasonable window function - should work
 	tokens := []token.Token{
-		{Type: "SELECT", Literal: "SELECT"},
+		{Type: "SELECT",
+			ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 		{Type: "IDENT", Literal: "ROW_NUMBER"},
 		{Type: "(", Literal: "("},
 		{Type: ")", Literal: ")"},
@@ -526,7 +539,8 @@ func TestParser_LogicalOperators(t *testing.T) {
 		{
 			name: "Simple AND",
 			tokens: []token.Token{
-				{Type: "SELECT", Literal: "SELECT"},
+				{Type: "SELECT",
+					ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 				{Type: "*", Literal: "*"},
 				{Type: "FROM", Literal: "FROM"},
 				{Type: "IDENT", Literal: "users"},
@@ -556,7 +570,8 @@ func TestParser_LogicalOperators(t *testing.T) {
 		{
 			name: "Simple OR",
 			tokens: []token.Token{
-				{Type: "SELECT", Literal: "SELECT"},
+				{Type: "SELECT",
+					ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 				{Type: "*", Literal: "*"},
 				{Type: "FROM", Literal: "FROM"},
 				{Type: "IDENT", Literal: "users"},
@@ -580,7 +595,8 @@ func TestParser_LogicalOperators(t *testing.T) {
 		{
 			name: "Three ANDs",
 			tokens: []token.Token{
-				{Type: "SELECT", Literal: "SELECT"},
+				{Type: "SELECT",
+					ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 				{Type: "*", Literal: "*"},
 				{Type: "FROM", Literal: "FROM"},
 				{Type: "IDENT", Literal: "users"},
@@ -613,7 +629,8 @@ func TestParser_LogicalOperators(t *testing.T) {
 		{
 			name: "Three ORs",
 			tokens: []token.Token{
-				{Type: "SELECT", Literal: "SELECT"},
+				{Type: "SELECT",
+					ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 				{Type: "*", Literal: "*"},
 				{Type: "FROM", Literal: "FROM"},
 				{Type: "IDENT", Literal: "users"},
@@ -646,7 +663,8 @@ func TestParser_LogicalOperators(t *testing.T) {
 		{
 			name: "AND with placeholders",
 			tokens: []token.Token{
-				{Type: "SELECT", Literal: "SELECT"},
+				{Type: "SELECT",
+					ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 				{Type: "*", Literal: "*"},
 				{Type: "FROM", Literal: "FROM"},
 				{Type: "IDENT", Literal: "users"},
@@ -676,7 +694,8 @@ func TestParser_LogicalOperators(t *testing.T) {
 		{
 			name: "OR with placeholders",
 			tokens: []token.Token{
-				{Type: "SELECT", Literal: "SELECT"},
+				{Type: "SELECT",
+					ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 				{Type: "*", Literal: "*"},
 				{Type: "FROM", Literal: "FROM"},
 				{Type: "IDENT", Literal: "users"},
@@ -700,7 +719,8 @@ func TestParser_LogicalOperators(t *testing.T) {
 		{
 			name: "Mixed AND/OR with literals",
 			tokens: []token.Token{
-				{Type: "SELECT", Literal: "SELECT"},
+				{Type: "SELECT",
+					ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 				{Type: "*", Literal: "*"},
 				{Type: "FROM", Literal: "FROM"},
 				{Type: "IDENT", Literal: "users"},
@@ -724,7 +744,8 @@ func TestParser_LogicalOperators(t *testing.T) {
 		{
 			name: "Multiple comparison operators",
 			tokens: []token.Token{
-				{Type: "SELECT", Literal: "SELECT"},
+				{Type: "SELECT",
+					ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 				{Type: "*", Literal: "*"},
 				{Type: "FROM", Literal: "FROM"},
 				{Type: "IDENT", Literal: "users"},
@@ -757,7 +778,8 @@ func TestParser_LogicalOperators(t *testing.T) {
 		{
 			name: "AND with inequality operators",
 			tokens: []token.Token{
-				{Type: "SELECT", Literal: "SELECT"},
+				{Type: "SELECT",
+					ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 				{Type: "*", Literal: "*"},
 				{Type: "FROM", Literal: "FROM"},
 				{Type: "IDENT", Literal: "users"},
@@ -789,7 +811,8 @@ func TestParser_LogicalOperators(t *testing.T) {
 		{
 			name: "Complex nested AND/OR",
 			tokens: []token.Token{
-				{Type: "SELECT", Literal: "SELECT"},
+				{Type: "SELECT",
+					ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 				{Type: "*", Literal: "*"},
 				{Type: "FROM", Literal: "FROM"},
 				{Type: "IDENT", Literal: "users"},
@@ -852,7 +875,8 @@ func TestParser_LogicalOperatorPrecedence(t *testing.T) {
 		{
 			name: "AND binds tighter than OR",
 			tokens: []token.Token{
-				{Type: "SELECT", Literal: "SELECT"},
+				{Type: "SELECT",
+					ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 				{Type: "*", Literal: "*"},
 				{Type: "FROM", Literal: "FROM"},
 				{Type: "IDENT", Literal: "t"},
@@ -874,7 +898,8 @@ func TestParser_LogicalOperatorPrecedence(t *testing.T) {
 		{
 			name: "Multiple ANDs with OR",
 			tokens: []token.Token{
-				{Type: "SELECT", Literal: "SELECT"},
+				{Type: "SELECT",
+					ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 				{Type: "*", Literal: "*"},
 				{Type: "FROM", Literal: "FROM"},
 				{Type: "IDENT", Literal: "t"},
@@ -941,7 +966,8 @@ func TestRecursionDepthLimit_ExtremelyNestedParentheses(t *testing.T) {
 	// Build tokens for: SELECT ((((...((x))...))) FROM t
 	// With 1000 levels of nested parentheses
 	tokens := []token.Token{
-		{Type: "SELECT", Literal: "SELECT"},
+		{Type: "SELECT",
+			ModelType: models.TokenTypeSelect, Literal: "SELECT"},
 	}
 
 	// Note: Parentheses in SQL expressions would require expression parsing
@@ -952,22 +978,22 @@ func TestRecursionDepthLimit_ExtremelyNestedParentheses(t *testing.T) {
 	// Add opening function calls (1000 levels)
 	for i := 0; i < 1000; i++ {
 		tokens = append(tokens,
-			token.Token{Type: "IDENT", Literal: "func"},
-			token.Token{Type: "(", Literal: "("},
+			token.Token{Type: "IDENT", ModelType: models.TokenTypeIdentifier, Literal: "func"},
+			token.Token{Type: "(", ModelType: models.TokenTypeLParen, Literal: "("},
 		)
 	}
 
 	// Add innermost argument
-	tokens = append(tokens, token.Token{Type: "IDENT", Literal: "x"})
+	tokens = append(tokens, token.Token{Type: "IDENT", ModelType: models.TokenTypeIdentifier, Literal: "x"})
 
 	// Add closing parentheses (1000 levels)
 	for i := 0; i < 1000; i++ {
-		tokens = append(tokens, token.Token{Type: ")", Literal: ")"})
+		tokens = append(tokens, token.Token{Type: ")", ModelType: models.TokenTypeRParen, Literal: ")"})
 	}
 
 	tokens = append(tokens,
-		token.Token{Type: "FROM", Literal: "FROM"},
-		token.Token{Type: "IDENT", Literal: "t"},
+		token.Token{Type: "FROM", ModelType: models.TokenTypeFrom, Literal: "FROM"},
+		token.Token{Type: "IDENT", ModelType: models.TokenTypeIdentifier, Literal: "t"},
 	)
 
 	// This should be rejected due to exceeding MaxRecursionDepth (100)
@@ -1007,24 +1033,24 @@ func TestRecursionDepthLimit_NoStackOverflow(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			// Build nested function call tokens
-			tokens := []token.Token{{Type: "SELECT", Literal: "SELECT"}}
+			tokens := []token.Token{{Type: "SELECT", ModelType: models.TokenTypeSelect, Literal: "SELECT"}}
 
 			for i := 0; i < tc.depth; i++ {
 				tokens = append(tokens,
-					token.Token{Type: "IDENT", Literal: "f"},
-					token.Token{Type: "(", Literal: "("},
+					token.Token{Type: "IDENT", ModelType: models.TokenTypeIdentifier, Literal: "f"},
+					token.Token{Type: "(", ModelType: models.TokenTypeLParen, Literal: "("},
 				)
 			}
 
-			tokens = append(tokens, token.Token{Type: "IDENT", Literal: "x"})
+			tokens = append(tokens, token.Token{Type: "IDENT", ModelType: models.TokenTypeIdentifier, Literal: "x"})
 
 			for i := 0; i < tc.depth; i++ {
-				tokens = append(tokens, token.Token{Type: ")", Literal: ")"})
+				tokens = append(tokens, token.Token{Type: ")", ModelType: models.TokenTypeRParen, Literal: ")"})
 			}
 
 			tokens = append(tokens,
-				token.Token{Type: "FROM", Literal: "FROM"},
-				token.Token{Type: "IDENT", Literal: "t"},
+				token.Token{Type: "FROM", ModelType: models.TokenTypeFrom, Literal: "FROM"},
+				token.Token{Type: "IDENT", ModelType: models.TokenTypeIdentifier, Literal: "t"},
 			)
 
 			// Parse and check result

--- a/pkg/sql/parser/recovery_multi_error_test.go
+++ b/pkg/sql/parser/recovery_multi_error_test.go
@@ -2,17 +2,18 @@ package parser
 
 import (
 	"errors"
+	"github.com/ajitpratap0/GoSQLX/pkg/models"
 	"testing"
 
 	"github.com/ajitpratap0/GoSQLX/pkg/sql/token"
 )
 
 func eof() token.Token {
-	return token.Token{Type: "EOF", Literal: ""}
+	return token.Token{Type: "EOF", ModelType: models.TokenTypeEOF, Literal: ""}
 }
 
 func semi() token.Token {
-	return token.Token{Type: ";", Literal: ";"}
+	return token.Token{Type: ";", ModelType: models.TokenTypeSemicolon, Literal: ";"}
 }
 
 func tok(typ, lit string) token.Token {


### PR DESCRIPTION
Part of #215 token type unification.

Updates all parser test files to set ModelType on token.Token structs, preparing for removal of string-based Type field.

Phase 2C of 4.