### PR TITLE
refactor(#215): Phase 3A — Migrate matchToken() to ModelType

### DIFF
--- a/pkg/sql/parser/expressions.go
+++ b/pkg/sql/parser/expressions.go
@@ -557,11 +557,6 @@ func (p *Parser) isNumericLiteral() bool {
 	if p.currentToken.ModelType != modelTypeUnset {
 		return p.currentToken.ModelType == models.TokenTypeNumber
 	}
-	// String fallback for tokens created without ModelType
-	switch p.currentToken.Type {
-	case "INT", "NUMBER", "FLOAT":
-		return true
-	}
 	return false
 }
 
@@ -866,7 +861,7 @@ func (p *Parser) parsePrimaryExpression() (ast.Expression, error) {
 	}
 
 	return nil, goerrors.UnexpectedTokenError(
-		string(p.currentToken.Type),
+		p.currentToken.ModelType.String(),
 		p.currentToken.Literal,
 		models.Location{Line: 0, Column: 0},
 		"",
@@ -1183,7 +1178,7 @@ func (p *Parser) parseSubquery() (ast.Statement, error) {
 
 	return nil, goerrors.ExpectedTokenError(
 		"SELECT or WITH",
-		string(p.currentToken.Type),
+		p.currentToken.ModelType.String(),
 		models.Location{Line: 0, Column: 0},
 		"",
 	)

--- a/pkg/sql/parser/recovery.go
+++ b/pkg/sql/parser/recovery.go
@@ -77,15 +77,6 @@ func (p *Parser) isStatementStartingKeyword() bool {
 			return true
 		}
 	}
-	// Fallback: string comparison for tokens without ModelType (e.g., tests)
-	switch string(p.currentToken.Type) {
-	case "SELECT", "INSERT", "UPDATE", "DELETE", "CREATE", "ALTER", "DROP",
-		"WITH", "MERGE", "REFRESH", "TRUNCATE",
-		"EXPLAIN", "ANALYZE", "SHOW", "DESCRIBE", "GRANT", "REVOKE",
-		"SET", "USE", "BEGIN", "COMMIT", "ROLLBACK", "VACUUM",
-		"CALL", "EXECUTE":
-		return true
-	}
 	return false
 }
 

--- a/pkg/sql/parser/select.go
+++ b/pkg/sql/parser/select.go
@@ -18,7 +18,7 @@ func (p *Parser) parseColumnDef() (*ast.ColumnDef, error) {
 	if name == nil {
 		return nil, goerrors.ExpectedTokenError(
 			"column name",
-			string(p.currentToken.Type),
+			p.currentToken.ModelType.String(),
 			p.currentLocation(),
 			"",
 		)
@@ -29,7 +29,7 @@ func (p *Parser) parseColumnDef() (*ast.ColumnDef, error) {
 	if dataType == nil {
 		return nil, goerrors.ExpectedTokenError(
 			"data type",
-			string(p.currentToken.Type),
+			p.currentToken.ModelType.String(),
 			p.currentLocation(),
 			"",
 		)
@@ -651,7 +651,7 @@ func (p *Parser) parseSelectStatement() (ast.Statement, error) {
 			if !p.isType(models.TokenTypeJoin) {
 				return nil, goerrors.ExpectedTokenError(
 					"JOIN after "+joinType,
-					string(p.currentToken.Type),
+					p.currentToken.ModelType.String(),
 					p.currentLocation(),
 					"",
 				)
@@ -705,7 +705,7 @@ func (p *Parser) parseSelectStatement() (ast.Statement, error) {
 				if err != nil {
 					return nil, goerrors.ExpectedTokenError(
 						"table name after "+joinType+" JOIN",
-						string(p.currentToken.Type),
+						p.currentToken.ModelType.String(),
 						p.currentLocation(),
 						"",
 					)


### PR DESCRIPTION
Part of #215 token type unification.

Migrates the last remaining string-based Type comparisons to int-based ModelType:
- matchToken() — the most-called parser comparison function
- isStringLiteral() — removed string fallback (tokens normalized at entry)
- isNumericLiteral() — removed string fallback
- isNonReservedKeyword() — uses ModelType with literal fallback for generic keywords
- recovery.go — removed string fallback in isStatementStart()
- Error message formatting across parser files (expressions.go, select.go, parser.go)

When ModelType is a specific type (not TokenTypeKeyword), matchToken uses O(1) integer comparison. For generic keywords that map to TokenTypeKeyword, it falls back to case-insensitive string comparison to avoid ambiguous matches.

Phase 3A of 3.