### PR TITLE
feat: publish GitHub Action to marketplace (#242)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 [![Release](https://img.shields.io/github/v/release/ajitpratap0/GoSQLX?style=for-the-badge&color=orange)](https://github.com/ajitpratap0/GoSQLX/releases)
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache--2.0-blue.svg?style=for-the-badge)](https://www.apache.org/licenses/LICENSE-2.0)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=for-the-badge)](http://makeapullrequest.com)
+[![GitHub Marketplace](https://img.shields.io/badge/Marketplace-GoSQLX%20Lint-blue?style=for-the-badge&logo=github)](https://github.com/marketplace/actions/gosqlx-sql-validator)
 
 [![Tests](https://img.shields.io/github/actions/workflow/status/ajitpratap0/GoSQLX/test.yml?branch=main&label=Tests&style=flat-square)](https://github.com/ajitpratap0/GoSQLX/actions)
 [![Go Report Card](https://goreportcard.com/badge/github.com/ajitpratap0/GoSQLX?style=flat-square)](https://goreportcard.com/report/github.com/ajitpratap0/GoSQLX)

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
-name: 'GoSQLX SQL Validator'
-description: 'Ultra-fast SQL validation, linting, and formatting with GoSQLX - 100x faster than SQLFluff'
+name: 'GoSQLX Lint Action'
+description: 'Ultra-fast SQL validation, linting, and formatting for your CI pipeline — 100x faster than SQLFluff. Supports PR annotations, SARIF output, and multi-dialect SQL.'
 author: 'GoSQLX Team'
 
 branding:


### PR DESCRIPTION
Closes #242

Adds marketplace metadata, branding, PR annotations, and usage docs for the GoSQLX lint GitHub Action.

### Changes
- Renamed action to **GoSQLX Lint Action** with enhanced description
- Added marketplace badge to main README.md
- Action already includes: branding (icon + color), PR annotations (`::error`/`::warning`), SARIF output, config file support, and comprehensive ACTION_README.md