### PR TITLE
refactor: rename pkg/optimizer → pkg/advisor (#243)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added - Query Optimization Engine (PR #210, closes #81)
-- New `pkg/optimizer/` package with 12 optimization rules
+- New `pkg/advisor/` package with 12 optimization rules
 - Rules OPT-001 through OPT-008: SELECT * detection, missing WHERE, Cartesian products, DISTINCT overuse, subquery in WHERE, OR in WHERE, leading wildcard LIKE, function on indexed column
 - Rules OPT-009 through OPT-012: N+1 query detection, index recommendations, join order optimization, query cost estimation
 - CLI command `gosqlx optimize` with text/JSON output

--- a/cmd/gosqlx/cmd/optimize.go
+++ b/cmd/gosqlx/cmd/optimize.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/ajitpratap0/GoSQLX/pkg/optimizer"
+	"github.com/ajitpratap0/GoSQLX/pkg/advisor"
 )
 
 // optimizeCmd represents the optimize command
@@ -78,7 +78,7 @@ func optimizeFromStdin(cmd *cobra.Command) error {
 
 // runOptimize performs the optimization analysis and outputs results
 func runOptimize(cmd *cobra.Command, sql string) error {
-	opt := optimizer.New()
+	opt := advisor.New()
 
 	result, err := opt.AnalyzeSQL(sql)
 	if err != nil {
@@ -111,15 +111,15 @@ func runOptimize(cmd *cobra.Command, sql string) error {
 }
 
 // outputOptimizeJSON writes the optimization result as JSON
-func outputOptimizeJSON(w io.Writer, result *optimizer.OptimizationResult) error {
+func outputOptimizeJSON(w io.Writer, result *advisor.OptimizationResult) error {
 	encoder := json.NewEncoder(w)
 	encoder.SetIndent("", "  ")
 	return encoder.Encode(result)
 }
 
 // outputOptimizeText writes the optimization result as human-readable text
-func outputOptimizeText(w io.Writer, result *optimizer.OptimizationResult) {
-	fmt.Fprint(w, optimizer.FormatResult(result))
+func outputOptimizeText(w io.Writer, result *advisor.OptimizationResult) {
+	fmt.Fprint(w, advisor.FormatResult(result))
 }
 
 func init() {

--- a/pkg/advisor/optimizer.go
+++ b/pkg/advisor/optimizer.go
@@ -1,4 +1,4 @@
-// Package optimizer provides SQL query optimization suggestions by analyzing parsed ASTs.
+// Package advisor provides SQL query optimization suggestions by analyzing parsed ASTs.
 //
 // The optimizer walks the Abstract Syntax Tree produced by the GoSQLX parser and
 // applies configurable rules to detect common performance anti-patterns. Each rule
@@ -20,7 +20,7 @@
 //
 //	astNode, _ := gosqlx.Parse(sql)
 //	result := opt.Analyze(astNode)
-package optimizer
+package advisor
 
 import (
 	"fmt"

--- a/pkg/advisor/optimizer_test.go
+++ b/pkg/advisor/optimizer_test.go
@@ -1,4 +1,4 @@
-package optimizer
+package advisor
 
 import (
 	"testing"

--- a/pkg/advisor/rules.go
+++ b/pkg/advisor/rules.go
@@ -1,4 +1,4 @@
-package optimizer
+package advisor
 
 import (
 	"fmt"


### PR DESCRIPTION
Closes #243

Renames optimizer package to advisor to better reflect its static analysis nature (pattern-matching lint rules, not query optimization).