### PR TITLE
refactor: replace custom DebugLogger with slog (#224)

### DIFF
--- a/pkg/sql/tokenizer/debug.go
+++ b/pkg/sql/tokenizer/debug.go
@@ -1,64 +1,29 @@
 package tokenizer
 
-// DebugLogger is an interface for debug logging during tokenization.
+import "log/slog"
+
+// SetLogger configures a structured logger for verbose tracing during tokenization.
+// The logger receives slog.Debug messages for each token produced, which is useful
+// for diagnosing tokenization issues or understanding token stream structure.
 //
-// Implementing this interface allows you to capture detailed trace information
-// about the tokenization process, including each token produced, position tracking,
-// and internal state transitions.
+// Pass nil to disable debug logging (the default).
 //
-// This is useful for:
-//   - Diagnosing tokenization issues with specific SQL queries
-//   - Understanding how SQL is broken into tokens
-//   - Debugging position tracking and error reporting
-//   - Performance analysis and profiling
-//   - Educational purposes (learning how SQL is tokenized)
+// Logging is guarded by slog.LevelDebug checks so there is no performance cost
+// when the handler's minimum level is above Debug.
 //
-// The Debug method will be called frequently during tokenization (potentially
-// once per token), so implementations should be efficient if performance matters.
+// Example:
 //
-// Example Implementation:
-//
-//	type FileLogger struct {
-//	    file *os.File
-//	}
-//
-//	func (l *FileLogger) Debug(format string, args ...interface{}) {
-//	    fmt.Fprintf(l.file, "[%s] ", time.Now().Format("15:04:05.000"))
-//	    fmt.Fprintf(l.file, format, args...)
-//	    fmt.Fprintln(l.file)
-//	}
-//
-//	// Usage:
-//	logger := &FileLogger{file: os.Stdout}
 //	tkz := tokenizer.GetTokenizer()
-//	tkz.SetDebugLogger(logger)
+//	tkz.SetLogger(slog.Default())
 //	tokens, _ := tkz.Tokenize([]byte(sql))
 //
-// Simple Console Logger:
+// To disable:
 //
-//	type ConsoleLogger struct{}
-//
-//	func (l *ConsoleLogger) Debug(format string, args ...interface{}) {
-//	    log.Printf("[TOKENIZER] "+format, args...)
-//	}
-//
-// No-Op Logger (for disabling):
-//
-//	tkz.SetDebugLogger(nil)  // Disable debug logging
+//	tkz.SetLogger(nil)
 //
 // Thread Safety:
-// Debug method may be called from multiple goroutines if multiple tokenizers
-// are in use concurrently. Implementations should be thread-safe if they will
-// be shared across tokenizer instances.
-type DebugLogger interface {
-	// Debug logs a debug message with printf-style formatting.
-	//
-	// Parameters:
-	//   - format: Printf-style format string
-	//   - args: Arguments to be formatted according to the format string
-	//
-	// The method should not return errors. If logging fails, the error
-	// should be handled internally (e.g., logged to stderr) rather than
-	// affecting tokenization.
-	Debug(format string, args ...interface{})
+// The logger may be called from multiple goroutines if tokenizers are used
+// concurrently. *slog.Logger is safe for concurrent use.
+func (t *Tokenizer) SetLogger(logger *slog.Logger) {
+	t.logger = logger
 }

--- a/pkg/sql/tokenizer/pool.go
+++ b/pkg/sql/tokenizer/pool.go
@@ -135,7 +135,7 @@ func PutTokenizer(t *Tokenizer) {
 //   - lineStarts: Empty slice with preserved capacity (contains [0])
 //   - input: nil (ready for new input)
 //   - keywords: Preserved (immutable, no need to reset)
-//   - debugLog: nil (must be set again if needed)
+//   - logger: nil (must be set again if needed)
 //
 // Performance: By preserving slice capacity, subsequent Tokenize() calls
 // avoid reallocation of lineStarts for similarly-sized inputs.
@@ -160,5 +160,5 @@ func (t *Tokenizer) Reset() {
 	t.line = 0
 
 	// Don't reset keywords as they're constant
-	t.debugLog = nil
+	t.logger = nil
 }

--- a/pkg/sql/tokenizer/tokenizer_coverage_test.go
+++ b/pkg/sql/tokenizer/tokenizer_coverage_test.go
@@ -2,6 +2,8 @@ package tokenizer
 
 import (
 	"context"
+	"io"
+	"log/slog"
 	"testing"
 
 	"github.com/ajitpratap0/GoSQLX/pkg/models"
@@ -615,29 +617,14 @@ func TestNewWithKeywords(t *testing.T) {
 	}
 }
 
-// mockDebugLogger is a simple mock implementation of DebugLogger
-type mockDebugLogger struct {
-	messages []string
-}
-
-func (m *mockDebugLogger) Debug(format string, args ...interface{}) {
-	// Store messages for potential verification
-	if m.messages == nil {
-		m.messages = make([]string, 0)
-	}
-	// We don't actually need to store them for this test
-}
-
-// TestSetDebugLogger tests the debug logger functionality
-func TestSetDebugLogger(t *testing.T) {
+// TestSetLogger tests the slog-based logger functionality
+func TestSetLogger(t *testing.T) {
 	tkz := GetTokenizer()
 	defer PutTokenizer(tkz)
 
-	// Create a mock logger
-	logger := &mockDebugLogger{}
-
-	// Set debug logger (should not panic)
-	tkz.SetDebugLogger(logger)
+	// Set a debug-level slog logger
+	logger := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	tkz.SetLogger(logger)
 
 	// Test that tokenization still works with logger set
 	input := "SELECT * FROM users"
@@ -651,7 +638,7 @@ func TestSetDebugLogger(t *testing.T) {
 	}
 
 	// Set logger to nil (should also work)
-	tkz.SetDebugLogger(nil)
+	tkz.SetLogger(nil)
 
 	// Test again
 	tokens, err = tkz.Tokenize([]byte(input))


### PR DESCRIPTION
Closes #224

Replaces the custom DebugLogger interface with Go's standard log/slog package (available since Go 1.21).

Changes:
- Removed DebugLogger interface and replaced with *slog.Logger field
- Added SetLogger(logger *slog.Logger) method (replaces SetDebugLogger)
- Added structured debug logging in both Tokenize and TokenizeContext hot paths, guarded by level checks (zero cost when debug is disabled)
- Updated pool reset to clear logger
- Updated tests to use slog with io.Discard handler