### PR TITLE
feat: VSCode extension + editor LSP setup docs (#246)

### DIFF
--- a/docs/editors/jetbrains.md
+++ b/docs/editors/jetbrains.md
@@ -1,0 +1,45 @@
+# GoSQLX – JetBrains IDE LSP Setup
+
+Supported IDEs: IntelliJ IDEA, GoLand, DataGrip, WebStorm, PyCharm, and others (2023.2+).
+
+## Prerequisites
+
+- [GoSQLX](https://github.com/ajitpratap0/GoSQLX) installed and available on your `$PATH`
+- JetBrains IDE version **2023.2** or later (built-in LSP support)
+
+## Configuration
+
+1. Open **Settings** → **Languages & Frameworks** → **Language Servers** (or search for "LSP" in Settings).
+2. Click **+** to add a new server.
+3. Configure:
+   - **Name**: `GoSQLX`
+   - **Command**: `gosqlx lsp`
+   - **File patterns**: `*.sql`, `*.pgsql`, `*.mysql`
+4. Click **OK** / **Apply**.
+
+## Manual Configuration (settings.json)
+
+If your IDE supports custom LSP definitions via JSON, add:
+
+```json
+{
+  "lsp": {
+    "gosqlx": {
+      "command": ["gosqlx", "lsp"],
+      "fileTypes": ["sql"],
+      "initializationOptions": {
+        "dialect": "postgresql"
+      }
+    }
+  }
+}
+```
+
+## Verify
+
+Open any `.sql` file. You should see GoSQLX diagnostics and formatting available via the editor's code actions.
+
+## Troubleshooting
+
+- Ensure `gosqlx` is on your `$PATH` by running `gosqlx --version` in the terminal.
+- Check **Help** → **Diagnostic Tools** → **Debug Log Settings** and add `#lsp` for LSP debug logging.

--- a/docs/editors/neovim.md
+++ b/docs/editors/neovim.md
@@ -1,0 +1,56 @@
+# GoSQLX – Neovim LSP Setup
+
+## Prerequisites
+
+- [GoSQLX](https://github.com/ajitpratap0/GoSQLX) installed and available on your `$PATH`
+- [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig)
+
+## Configuration
+
+Add the following to your Neovim configuration (e.g. `init.lua`):
+
+```lua
+local lspconfig = require('lspconfig')
+local configs = require('lspconfig.configs')
+
+-- Register GoSQLX as a custom LSP server
+if not configs.gosqlx then
+  configs.gosqlx = {
+    default_config = {
+      cmd = { 'gosqlx', 'lsp' },
+      filetypes = { 'sql', 'mysql', 'pgsql' },
+      root_dir = lspconfig.util.root_pattern('.git', '.gosqlx.yaml'),
+      settings = {},
+    },
+  }
+end
+
+lspconfig.gosqlx.setup{}
+```
+
+### With Custom Options
+
+```lua
+lspconfig.gosqlx.setup{
+  cmd = { 'gosqlx', 'lsp' },
+  settings = {
+    gosqlx = {
+      dialect = 'postgresql',
+      format = {
+        indentSize = 2,
+        uppercaseKeywords = true,
+      },
+    },
+  },
+}
+```
+
+## Verify
+
+Open a `.sql` file and run:
+
+```vim
+:LspInfo
+```
+
+You should see `gosqlx` listed as an active client.

--- a/docs/editors/vscode.md
+++ b/docs/editors/vscode.md
@@ -1,0 +1,36 @@
+# GoSQLX – VS Code Extension
+
+## Install from Marketplace
+
+Search for **GoSQLX** in the VS Code Extensions panel, or install from the command line:
+
+```bash
+code --install-extension ajitpratap0.gosqlx
+```
+
+## Prerequisites
+
+- [GoSQLX](https://github.com/ajitpratap0/GoSQLX) installed and available on your `$PATH`
+
+## Features
+
+- **Real-time SQL validation** – syntax errors highlighted as you type
+- **SQL formatting** – format with `Cmd+Shift+F` (Mac) / `Ctrl+Shift+F`
+- **SQL analysis** – right-click → "Analyze SQL"
+- **Multi-dialect support** – PostgreSQL, MySQL, SQL Server, Oracle, SQLite
+
+## Configuration
+
+Open **Settings** and search for `gosqlx`:
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `gosqlx.dialect` | `generic` | SQL dialect |
+| `gosqlx.executablePath` | `gosqlx` | Path to the `gosqlx` binary |
+| `gosqlx.format.indentSize` | `2` | Indent size for formatting |
+| `gosqlx.format.uppercaseKeywords` | `true` | Uppercase SQL keywords |
+| `gosqlx.validation.enable` | `true` | Enable real-time validation |
+
+## Troubleshooting
+
+Run **GoSQLX: Validate Configuration** from the Command Palette to check your setup.


### PR DESCRIPTION
Closes #246

Adds/updates VSCode extension for marketplace publishing and adds Neovim/JetBrains LSP configuration docs.