### PR TITLE
perf(#269): pool TokenConverter — eliminate per-call map allocation

### DIFF
--- a/pkg/gosqlx/gosqlx.go
+++ b/pkg/gosqlx/gosqlx.go
@@ -142,7 +142,8 @@ func Parse(sql string) (*ast.AST, error) {
 	}
 
 	// Step 3: Convert to parser tokens using the proper converter
-	converter := parser.NewTokenConverter()
+	converter := parser.GetTokenConverter()
+	defer parser.PutTokenConverter(converter)
 	result, err := converter.Convert(tokens)
 	if err != nil {
 		return nil, fmt.Errorf("token conversion failed: %w", err)
@@ -236,7 +237,8 @@ func ParseWithContext(ctx context.Context, sql string) (*ast.AST, error) {
 	}
 
 	// Step 3: Convert to parser tokens using the proper converter
-	converter := parser.NewTokenConverter()
+	converter := parser.GetTokenConverter()
+	defer parser.PutTokenConverter(converter)
 	result, err := converter.Convert(tokens)
 	if err != nil {
 		return nil, fmt.Errorf("token conversion failed: %w", err)
@@ -405,7 +407,8 @@ func ParseMultiple(queries []string) ([]*ast.AST, error) {
 	p := parser.NewParser()
 	defer p.Release()
 
-	converter := parser.NewTokenConverter()
+	converter := parser.GetTokenConverter()
+	defer parser.PutTokenConverter(converter)
 
 	results := make([]*ast.AST, 0, len(queries))
 
@@ -458,7 +461,8 @@ func ValidateMultiple(queries []string) error {
 	p := parser.NewParser()
 	defer p.Release()
 
-	converter := parser.NewTokenConverter()
+	converter := parser.GetTokenConverter()
+	defer parser.PutTokenConverter(converter)
 
 	for i, sql := range queries {
 		tkz.Reset()
@@ -629,7 +633,8 @@ func ParseWithRecovery(sql string) ([]ast.Statement, []error) {
 		return nil, []error{fmt.Errorf("tokenization failed: %w", err)}
 	}
 
-	converter := parser.NewTokenConverter()
+	converter := parser.GetTokenConverter()
+	defer parser.PutTokenConverter(converter)
 	result, err := converter.Convert(tokens)
 	if err != nil {
 		return nil, []error{fmt.Errorf("token conversion failed: %w", err)}

--- a/pkg/gosqlx/gosqlx_test.go
+++ b/pkg/gosqlx/gosqlx_test.go
@@ -275,6 +275,7 @@ func TestValidateMultiple(t *testing.T) {
 func BenchmarkParse(b *testing.B) {
 	sql := "SELECT id, name, email FROM users WHERE age > 18"
 
+	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		_, err := Parse(sql)


### PR DESCRIPTION
## Summary

Eliminates per-call allocation of the TokenConverter's type mapping (150+ entry map) and the converter struct itself.

### Changes

1. **Singleton type mapping** — `buildTypeMapping()` result cached via `sync.Once` in package-level `globalTypeMap`. The mapping is static and never changes at runtime.

2. **Pooled TokenConverter** — `sync.Pool`-based `GetTokenConverter()`/`PutTokenConverter()` API (mirrors existing parser/tokenizer pooling pattern).

3. **Updated callers** — All 5 call sites in `pkg/gosqlx/gosqlx.go` now use pooled converters with deferred return.

### Benchmark (Apple M4, 10 cores)

```
BenchmarkParse-10          485956    2460 ns/op    6086 B/op    56 allocs/op
BenchmarkParseMultiple-10   98815   12630 ns/op   16740 B/op   126 allocs/op
```

Closes #269