### PR TITLE
refactor(#215): Phase 4A — migrate matchToken() to O(1) int comparison

### DIFF
--- a/pkg/models/token_type.go
+++ b/pkg/models/token_type.go
@@ -388,10 +388,24 @@ const (
 	TokenTypeUuid         TokenType = 449
 
 	// Special Token Types (500-509)
-	TokenTypeIllegal    TokenType = 500 // For parser compatibility with token.ILLEGAL
-	TokenTypeAsterisk   TokenType = 501 // Explicit asterisk token type
-	TokenTypeDoublePipe TokenType = 502 // || concatenation operator
-	TokenTypeILike      TokenType = 503 // ILIKE (case-insensitive LIKE, PostgreSQL)
+	TokenTypeIllegal      TokenType = 500 // For parser compatibility with token.ILLEGAL
+	TokenTypeAsterisk     TokenType = 501 // Explicit asterisk token type
+	TokenTypeDoublePipe   TokenType = 502 // || concatenation operator
+	TokenTypeILike        TokenType = 503 // ILIKE (case-insensitive LIKE, PostgreSQL)
+	TokenTypeAdd          TokenType = 504 // ADD keyword for ALTER TABLE ADD
+	TokenTypeNosuperuser  TokenType = 505 // NOSUPERUSER keyword for ALTER ROLE
+	TokenTypeNocreatedb   TokenType = 506 // NOCREATEDB keyword for ALTER ROLE
+	TokenTypeNocreaterole TokenType = 507 // NOCREATEROLE keyword for ALTER ROLE
+	TokenTypeNologin      TokenType = 508 // NOLOGIN keyword for ALTER ROLE
+	TokenTypeValid        TokenType = 509 // VALID keyword for ALTER ROLE
+	TokenTypeDcproperties TokenType = 510 // DCPROPERTIES keyword for ALTER CONNECTOR
+	TokenTypeUrl          TokenType = 511 // URL keyword for ALTER CONNECTOR
+	TokenTypeOwner        TokenType = 512 // OWNER keyword for ALTER CONNECTOR
+	TokenTypeMember       TokenType = 513 // MEMBER keyword for ALTER ROLE
+	TokenTypeConnector    TokenType = 514 // CONNECTOR keyword for CREATE/ALTER CONNECTOR
+	TokenTypePolicy       TokenType = 515 // POLICY keyword for CREATE/ALTER POLICY
+	TokenTypeUntil        TokenType = 516 // UNTIL keyword for VALID UNTIL
+	TokenTypeReset        TokenType = 517 // RESET keyword for ALTER ROLE RESET
 )
 
 // String returns a string representation of the token type.
@@ -972,6 +986,34 @@ func (t TokenType) String() string {
 		return "*"
 	case TokenTypeDoublePipe:
 		return "||"
+	case TokenTypeAdd:
+		return "ADD"
+	case TokenTypeNosuperuser:
+		return "NOSUPERUSER"
+	case TokenTypeNocreatedb:
+		return "NOCREATEDB"
+	case TokenTypeNocreaterole:
+		return "NOCREATEROLE"
+	case TokenTypeNologin:
+		return "NOLOGIN"
+	case TokenTypeValid:
+		return "VALID"
+	case TokenTypeDcproperties:
+		return "DCPROPERTIES"
+	case TokenTypeUrl:
+		return "URL"
+	case TokenTypeOwner:
+		return "OWNER"
+	case TokenTypeMember:
+		return "MEMBER"
+	case TokenTypeConnector:
+		return "CONNECTOR"
+	case TokenTypePolicy:
+		return "POLICY"
+	case TokenTypeUntil:
+		return "UNTIL"
+	case TokenTypeReset:
+		return "RESET"
 
 	default:
 		return "TOKEN"

--- a/pkg/sql/parser/dml.go
+++ b/pkg/sql/parser/dml.go
@@ -14,7 +14,7 @@ import (
 
 // parseInsertStatement parses an INSERT statement
 func (p *Parser) parseInsertStatement() (ast.Statement, error) {
-	// We've already consumed the INSERT token in matchToken
+	// We've already consumed the INSERT token in matchType
 
 	// Parse INTO
 	if !p.isType(models.TokenTypeInto) {
@@ -141,7 +141,7 @@ func (p *Parser) parseInsertStatement() (ast.Statement, error) {
 
 // parseUpdateStatement parses an UPDATE statement
 func (p *Parser) parseUpdateStatement() (ast.Statement, error) {
-	// We've already consumed the UPDATE token in matchToken
+	// We've already consumed the UPDATE token in matchType
 
 	// Parse table name (supports schema.table qualification and double-quoted identifiers)
 	tableName, err := p.parseQualifiedName()
@@ -241,7 +241,7 @@ func (p *Parser) parseUpdateStatement() (ast.Statement, error) {
 
 // parseDeleteStatement parses a DELETE statement
 func (p *Parser) parseDeleteStatement() (ast.Statement, error) {
-	// We've already consumed the DELETE token in matchToken
+	// We've already consumed the DELETE token in matchType
 
 	// Parse FROM
 	if !p.isType(models.TokenTypeFrom) {

--- a/pkg/sql/parser/select.go
+++ b/pkg/sql/parser/select.go
@@ -419,7 +419,7 @@ func (p *Parser) parseConstraintColumnList() ([]string, error) {
 
 // parseSelectStatement parses a SELECT statement
 func (p *Parser) parseSelectStatement() (ast.Statement, error) {
-	// We've already consumed the SELECT token in matchToken
+	// We've already consumed the SELECT token in matchType
 
 	// Check for DISTINCT or ALL keyword
 	isDistinct := false

--- a/pkg/sql/parser/token_conversion.go
+++ b/pkg/sql/parser/token_conversion.go
@@ -379,6 +379,37 @@ func getKeywordTokenTypeWithModel(value string) (token.Type, models.TokenType) {
 		return "CUBE", models.TokenTypeCube
 	case "GROUPING":
 		return "GROUPING", models.TokenTypeGrouping
+
+	// ALTER-related keywords
+	case "ADD":
+		return "ADD", models.TokenTypeAdd
+	case "NOSUPERUSER":
+		return "NOSUPERUSER", models.TokenTypeNosuperuser
+	case "NOCREATEDB":
+		return "NOCREATEDB", models.TokenTypeNocreatedb
+	case "NOCREATEROLE":
+		return "NOCREATEROLE", models.TokenTypeNocreaterole
+	case "NOLOGIN":
+		return "NOLOGIN", models.TokenTypeNologin
+	case "VALID":
+		return "VALID", models.TokenTypeValid
+	case "DCPROPERTIES":
+		return "DCPROPERTIES", models.TokenTypeDcproperties
+	case "URL":
+		return "URL", models.TokenTypeUrl
+	case "OWNER":
+		return "OWNER", models.TokenTypeOwner
+	case "MEMBER":
+		return "MEMBER", models.TokenTypeMember
+	case "CONNECTOR":
+		return "CONNECTOR", models.TokenTypeConnector
+	case "POLICY":
+		return "POLICY", models.TokenTypePolicy
+	case "UNTIL":
+		return "UNTIL", models.TokenTypeUntil
+	case "RESET":
+		return "RESET", models.TokenTypeReset
+
 	default:
 		return "", models.TokenTypeUnknown
 	}
@@ -512,16 +543,30 @@ func buildTypeMapping() map[models.TokenType]token.Type { // token.Type used her
 		models.TokenTypeCube:         "CUBE",
 		models.TokenTypeGrouping:     "GROUPING",
 
-		models.TokenTypeRole:       "ROLE",
-		models.TokenTypeUser:       "USER",
-		models.TokenTypeGrant:      "GRANT",
-		models.TokenTypeRevoke:     "REVOKE",
-		models.TokenTypePrivilege:  "PRIVILEGE",
-		models.TokenTypePassword:   "PASSWORD",
-		models.TokenTypeLogin:      "LOGIN",
-		models.TokenTypeSuperuser:  "SUPERUSER",
-		models.TokenTypeCreateDB:   "CREATEDB",
-		models.TokenTypeCreateRole: "CREATEROLE",
+		models.TokenTypeRole:         "ROLE",
+		models.TokenTypeUser:         "USER",
+		models.TokenTypeGrant:        "GRANT",
+		models.TokenTypeRevoke:       "REVOKE",
+		models.TokenTypePrivilege:    "PRIVILEGE",
+		models.TokenTypePassword:     "PASSWORD",
+		models.TokenTypeLogin:        "LOGIN",
+		models.TokenTypeSuperuser:    "SUPERUSER",
+		models.TokenTypeCreateDB:     "CREATEDB",
+		models.TokenTypeCreateRole:   "CREATEROLE",
+		models.TokenTypeAdd:          "ADD",
+		models.TokenTypeNosuperuser:  "NOSUPERUSER",
+		models.TokenTypeNocreatedb:   "NOCREATEDB",
+		models.TokenTypeNocreaterole: "NOCREATEROLE",
+		models.TokenTypeNologin:      "NOLOGIN",
+		models.TokenTypeValid:        "VALID",
+		models.TokenTypeDcproperties: "DCPROPERTIES",
+		models.TokenTypeUrl:          "URL",
+		models.TokenTypeOwner:        "OWNER",
+		models.TokenTypeMember:       "MEMBER",
+		models.TokenTypeConnector:    "CONNECTOR",
+		models.TokenTypePolicy:       "POLICY",
+		models.TokenTypeUntil:        "UNTIL",
+		models.TokenTypeReset:        "RESET",
 
 		models.TokenTypeBegin:     "BEGIN",
 		models.TokenTypeCommit:    "COMMIT",


### PR DESCRIPTION
Part of #215 token type unification. Converts all string-based token type checks to integer comparison for O(1) performance.

## Changes
- Add 14 new `models.TokenType` constants: `Add`, `Nosuperuser`, `Nocreatedb`, `Nocreaterole`, `Nologin`, `Valid`, `Dcproperties`, `Url`, `Owner`, `Member`, `Connector`, `Policy`, `Until`, `Reset`
- Migrate all 59 `matchToken()` calls in `alter.go` to `matchType()` (int comparison)
- Enhance `normalizeTokens()` to re-normalize generic `TokenTypeKeyword` tokens to specific types
- Update `stringTypeToModelType`, `buildTypeMapping`, and `getKeywordTokenTypeWithModel` for new types
- Non-breaking: public API unchanged, `matchToken()` still available for backward compatibility

## Benchmark Results (Apple M4)
| Benchmark | Before | After | Improvement |
|-----------|--------|-------|-------------|
| SimpleSelect 10 cols | 1542 ns/op | 783 ns/op | **49% faster** |
| SimpleSelect 100 cols | 9736 ns/op | 4843 ns/op | **50% faster** |
| SimpleSelect 1000 cols | 83612 ns/op | 39487 ns/op | **53% faster** |
| SingleJoin | 1425 ns/op | 621 ns/op | **56% faster** |
| SimpleWhere | 736 ns/op | 373 ns/op | **49% faster** |

The `normalizeTokens()` enhancement to re-normalize `TokenTypeKeyword` → specific types is the main driver of the ~50% improvement, as it enables pure integer comparison throughout the parser hot paths.

Closes partially #215