### PR TITLE
fix(transform): validate SetLimit rejects negative values

### DIFF
--- a/pkg/transform/limit_test.go
+++ b/pkg/transform/limit_test.go
@@ -72,6 +72,38 @@ func TestSetLimit_Negative(t *testing.T) {
 	}
 }
 
+func TestSetLimit_NegativeLarge(t *testing.T) {
+	stmt := mustParse(t, "SELECT * FROM users")
+	err := Apply(stmt, SetLimit(-100))
+	if err == nil {
+		t.Fatal("expected error for negative limit")
+	}
+}
+
+func TestSetLimit_Zero(t *testing.T) {
+	// LIMIT 0 is valid SQL — returns an empty result set.
+	stmt := mustParse(t, "SELECT * FROM users")
+	err := Apply(stmt, SetLimit(0))
+	if err != nil {
+		t.Fatalf("SetLimit(0) should succeed: %v", err)
+	}
+	out := format(stmt)
+	assertContains(t, out, "LIMIT")
+	assertContains(t, out, "0")
+}
+
+func TestSetOffset_Zero(t *testing.T) {
+	// OFFSET 0 is valid SQL — no offset applied.
+	stmt := mustParse(t, "SELECT * FROM users")
+	err := Apply(stmt, SetOffset(0))
+	if err != nil {
+		t.Fatalf("SetOffset(0) should succeed: %v", err)
+	}
+	out := format(stmt)
+	assertContains(t, out, "OFFSET")
+	assertContains(t, out, "0")
+}
+
 func TestSetOffset_Negative(t *testing.T) {
 	stmt := mustParse(t, "SELECT * FROM users")
 	err := Apply(stmt, SetOffset(-5))


### PR DESCRIPTION
Fixes #291

SetLimit already validated negative values at runtime, but test coverage was incomplete. This adds tests for:
- SetLimit(-100) — large negative value
- SetLimit(0) — valid SQL (LIMIT 0 returns empty result set)  
- SetOffset(0) — valid SQL (no offset)