### PR TITLE
fix(cli): return non-zero exit codes on errors

### DIFF
--- a/cmd/gosqlx/cmd/format.go
+++ b/cmd/gosqlx/cmd/format.go
@@ -102,6 +102,11 @@ func formatRun(cmd *cobra.Command, args []string) error {
 		os.Exit(1)
 	}
 
+	// Exit with error code if any files failed to format
+	if result.FailedFiles > 0 {
+		return fmt.Errorf("%d file(s) failed to format", result.FailedFiles)
+	}
+
 	return nil
 }
 

--- a/cmd/gosqlx/cmd/lint.go
+++ b/cmd/gosqlx/cmd/lint.go
@@ -167,10 +167,14 @@ func lintRun(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// Exit with error code if there were violations
+	// Exit with error code if there were violations or file errors
 	errorCount := 0
 	warningCount := 0
+	fileErrorCount := 0
 	for _, fileResult := range result.Files {
+		if fileResult.Error != nil {
+			fileErrorCount++
+		}
 		for _, violation := range fileResult.Violations {
 			switch violation.Severity {
 			case linter.SeverityError:
@@ -181,7 +185,10 @@ func lintRun(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// Exit with error if there are errors, or warnings with fail-on-warn flag
+	// Exit with error if there are file errors, lint errors, or warnings with fail-on-warn flag
+	if fileErrorCount > 0 {
+		return fmt.Errorf("%d file(s) had errors", fileErrorCount)
+	}
 	if errorCount > 0 || (lintFailOnWarn && warningCount > 0) {
 		os.Exit(1)
 	}

--- a/cmd/gosqlx/cmd/lint_test.go
+++ b/cmd/gosqlx/cmd/lint_test.go
@@ -152,8 +152,8 @@ func TestLintCmd_NonExistentFile(t *testing.T) {
 	args := []string{"/nonexistent/file.sql"}
 	err := lintRun(cmd, args)
 
-	if err != nil {
-		t.Errorf("Command should not return error for file read failure: %v", err)
+	if err == nil {
+		t.Errorf("Command should return error for file read failure")
 	}
 
 	output := outBuf.String()


### PR DESCRIPTION
Fixes #289

## Problem
The `format` and `lint` CLI commands were returning exit code 0 even when errors occurred (e.g., file not found, format failures). This broke CI/CD integration.

## Fix
- **format**: Return error when `FailedFiles > 0` after formatting attempt
- **lint**: Return error when files have read errors (previously only checked violation counts)
- Updated test to expect error on non-existent file

## Verification
```
gosqlx format "INVALID"    → exit 1 ✓
gosqlx lint "INVALID"      → exit 1 ✓
gosqlx parse "INVALID"     → exit 1 ✓ (already worked)
gosqlx validate "INVALID"  → exit 1 ✓ (already worked)
echo "SELECT 1" | gosqlx format → exit 0 ✓
echo "SELECT 1" | gosqlx lint   → exit 0 ✓
```