### PR TITLE
feat: Comment preservation in AST (#275)

### DIFF
--- a/pkg/formatter/comment_preservation_test.go
+++ b/pkg/formatter/comment_preservation_test.go
@@ -1,0 +1,103 @@
+package formatter
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestFormat_LineCommentPreservation(t *testing.T) {
+	f := New(Options{Compact: true})
+
+	t.Run("leading line comment", func(t *testing.T) {
+		input := "-- header comment\nSELECT col FROM t"
+		result, err := f.Format(input)
+		if err != nil {
+			t.Fatalf("Format() error = %v", err)
+		}
+		if !strings.Contains(result, "-- header comment") {
+			t.Errorf("Expected leading comment preserved, got: %s", result)
+		}
+		if !strings.Contains(result, "SELECT") || !strings.Contains(result, "col") {
+			t.Errorf("Expected SQL preserved, got: %s", result)
+		}
+	})
+
+	t.Run("trailing line comment", func(t *testing.T) {
+		input := "SELECT col FROM t -- trailing"
+		result, err := f.Format(input)
+		if err != nil {
+			t.Fatalf("Format() error = %v", err)
+		}
+		if !strings.Contains(result, "-- trailing") {
+			t.Errorf("Expected trailing comment preserved, got: %s", result)
+		}
+	})
+}
+
+func TestFormat_BlockCommentPreservation(t *testing.T) {
+	f := New(Options{Compact: true})
+
+	t.Run("leading block comment", func(t *testing.T) {
+		input := "/* header */\nSELECT col FROM t"
+		result, err := f.Format(input)
+		if err != nil {
+			t.Fatalf("Format() error = %v", err)
+		}
+		if !strings.Contains(result, "/* header */") {
+			t.Errorf("Expected block comment preserved, got: %s", result)
+		}
+	})
+
+	t.Run("inline block comment", func(t *testing.T) {
+		input := "SELECT /* inline */ col FROM t"
+		result, err := f.Format(input)
+		if err != nil {
+			t.Fatalf("Format() error = %v", err)
+		}
+		if !strings.Contains(result, "/* inline */") {
+			t.Errorf("Expected inline block comment preserved, got: %s", result)
+		}
+	})
+}
+
+func TestFormat_CommentRoundTrip(t *testing.T) {
+	f := New(Options{Compact: true})
+
+	inputs := []string{
+		"-- header\nSELECT col FROM t",
+		"SELECT col FROM t -- trailing",
+		"/* block */ SELECT col FROM t",
+	}
+
+	for _, input := range inputs {
+		t.Run(input, func(t *testing.T) {
+			first, err := f.Format(input)
+			if err != nil {
+				t.Fatalf("First format error: %v", err)
+			}
+			second, err := f.Format(first)
+			if err != nil {
+				t.Fatalf("Second format error: %v", err)
+			}
+			if first != second {
+				t.Errorf("Round-trip mismatch:\n  first:  %q\n  second: %q", first, second)
+			}
+		})
+	}
+}
+
+func TestFormat_MultipleComments(t *testing.T) {
+	f := New(Options{Compact: true})
+
+	input := "-- first comment\n-- second comment\nSELECT col FROM t"
+	result, err := f.Format(input)
+	if err != nil {
+		t.Fatalf("Format() error = %v", err)
+	}
+	if !strings.Contains(result, "-- first comment") {
+		t.Errorf("Expected first comment, got: %s", result)
+	}
+	if !strings.Contains(result, "-- second comment") {
+		t.Errorf("Expected second comment, got: %s", result)
+	}
+}

--- a/pkg/formatter/formatter.go
+++ b/pkg/formatter/formatter.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/ajitpratap0/GoSQLX/pkg/models"
 	"github.com/ajitpratap0/GoSQLX/pkg/sql/ast"
 	"github.com/ajitpratap0/GoSQLX/pkg/sql/parser"
 	"github.com/ajitpratap0/GoSQLX/pkg/sql/tokenizer"
@@ -53,12 +54,21 @@ func (f *Formatter) Format(sql string) (string, error) {
 		return "", nil
 	}
 
+	// Capture comments from tokenizer before parsing
+	comments := tkz.Comments
+
 	p := parser.NewParser()
 	parsedAST, err := p.ParseFromModelTokens(tokens)
 	if err != nil {
 		return "", fmt.Errorf("parsing failed: %w", err)
 	}
 	defer ast.ReleaseAST(parsedAST)
+
+	// Attach captured comments to AST
+	if len(comments) > 0 {
+		parsedAST.Comments = make([]models.Comment, len(comments))
+		copy(parsedAST.Comments, comments)
+	}
 
 	// Use AST's built-in Format method
 	style := ast.ReadableStyle()

--- a/pkg/models/comment.go
+++ b/pkg/models/comment.go
@@ -1,0 +1,21 @@
+// Package models provides the Comment type for SQL comment preservation.
+package models
+
+// CommentStyle indicates the type of SQL comment.
+type CommentStyle int
+
+const (
+	// LineComment represents a -- single-line comment.
+	LineComment CommentStyle = iota
+	// BlockComment represents a /* multi-line */ comment.
+	BlockComment
+)
+
+// Comment represents a SQL comment captured during tokenization.
+type Comment struct {
+	Text   string       // The comment text including delimiters (e.g., "-- foo" or "/* bar */")
+	Style  CommentStyle // Line or block comment
+	Start  Location     // Start position in source
+	End    Location     // End position in source
+	Inline bool         // True if the comment is on the same line as code (trailing)
+}

--- a/pkg/sql/ast/ast.go
+++ b/pkg/sql/ast/ast.go
@@ -32,7 +32,11 @@
 // FILTER clause, RETURNING clause, JSON/JSONB operators, and FETCH FIRST/NEXT.
 package ast
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/ajitpratap0/GoSQLX/pkg/models"
+)
 
 // Node represents any node in the Abstract Syntax Tree.
 //
@@ -1684,6 +1688,7 @@ func (p PartitionDefinition) Children() []Node {
 // AST represents the root of the Abstract Syntax Tree
 type AST struct {
 	Statements []Statement
+	Comments   []models.Comment // Comments captured during tokenization, preserved during formatting
 }
 
 func (a AST) TokenLiteral() string { return "" }

--- a/pkg/sql/ast/format.go
+++ b/pkg/sql/ast/format.go
@@ -138,7 +138,34 @@ func (a AST) Format(opts FormatOptions) string {
 		// Each statement already gets semicolons from its own Format
 		sep = "\n"
 	}
-	return strings.Join(parts, sep)
+	result := strings.Join(parts, sep)
+
+	// Emit preserved comments around the formatted SQL
+	if len(a.Comments) > 0 {
+		var leading, trailing []string
+		for _, c := range a.Comments {
+			if c.Inline {
+				// Inline comments (on same line as code) → trailing
+				trailing = append(trailing, c.Text)
+			} else {
+				// Comments on their own line → leading
+				leading = append(leading, c.Text)
+			}
+		}
+		var sb strings.Builder
+		for _, lc := range leading {
+			sb.WriteString(lc)
+			sb.WriteString("\n")
+		}
+		sb.WriteString(result)
+		for _, tc := range trailing {
+			sb.WriteString(" ")
+			sb.WriteString(tc)
+		}
+		result = sb.String()
+	}
+
+	return result
 }
 
 // Format returns formatted SQL for a SelectStatement.

--- a/pkg/sql/ast/pool.go
+++ b/pkg/sql/ast/pool.go
@@ -353,6 +353,11 @@ func ReleaseAST(ast *AST) {
 	// Reset slice but keep capacity
 	ast.Statements = ast.Statements[:0]
 
+	// Reset comments but keep capacity
+	if cap(ast.Comments) > 0 {
+		ast.Comments = ast.Comments[:0]
+	}
+
 	// Return to pool
 	astPool.Put(ast)
 }

--- a/pkg/sql/tokenizer/pool.go
+++ b/pkg/sql/tokenizer/pool.go
@@ -161,4 +161,9 @@ func (t *Tokenizer) Reset() {
 
 	// Don't reset keywords as they're constant
 	t.logger = nil
+
+	// Preserve Comments slice capacity but reset length
+	if cap(t.Comments) > 0 {
+		t.Comments = t.Comments[:0]
+	}
 }


### PR DESCRIPTION
Closes #275

## Changes
- Added `models.Comment` type for representing SQL comments with position info
- Tokenizer now captures line (`--`) and block (`/* */`) comments during tokenization
- AST stores captured comments and emits them during formatting
- Formatter preserves comments through parse→format round-trips
- Fixed AST pool to properly reset comments on release
- Added comprehensive tests for comment preservation