### PR TITLE
fix: bump Version constant to 1.8.0

### DIFF
--- a/pkg/gosqlx/gosqlx.go
+++ b/pkg/gosqlx/gosqlx.go
@@ -62,7 +62,7 @@ import (
 )
 
 // Version is the current GoSQLX library version.
-const Version = "1.7.0"
+const Version = "1.8.0"
 
 // Parse tokenizes and parses SQL in one call, returning an Abstract Syntax Tree (AST).
 //


### PR DESCRIPTION
The `gosqlx.Version` constant was still set to `1.7.0` after the v1.8.0 release. This updates it to match the tagged release.