### PR TITLE
fix: bump minimatch 10.2.1→10.2.3 (CVE-2026-27903, CVE-2026-27904)

### DIFF
--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -3484,15 +3484,15 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "10.2.1",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.1.tgz",
-      "integrity": "sha512-MClCe8IL5nRRmawL6ib/eT4oLyeKMGCghibcDWK+J0hh0Q8kqSdia6BvbRMVk6mPa6WqUa5uR2oxt6C5jd533A==",
+      "version": "10.2.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.3.tgz",
+      "integrity": "sha512-Rwi3pnapEqirPSbWbrZaa6N3nmqq4Xer/2XooiOKyV3q12ML06f7MOuc5DVH8ONZIFhwIYQ3yzPH4nt7iWHaTg==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "brace-expansion": "^5.0.2"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -266,6 +266,6 @@
     "typescript": "^5.3.2"
   },
   "overrides": {
-    "minimatch": "10.2.1"
+    "minimatch": "10.2.3"
   }
 }


### PR DESCRIPTION
Bumps minimatch from 10.2.1 to 10.2.3 in vscode-extension to resolve HIGH severity CVEs:
- CVE-2026-27903
- CVE-2026-27904

Updates both the direct dependency and the override in package.json.