### PR TITLE
fix: address multi-agent review issues — pool safety, EOF sentinel, ReDoS guard, formatter pool

### DIFF
--- a/pkg/errors/builders.go
+++ b/pkg/errors/builders.go
@@ -16,6 +16,7 @@ package errors
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/ajitpratap0/GoSQLX/pkg/models"
 )
@@ -271,12 +272,5 @@ func AmbiguousColumnError(columnName string, tables []string, location models.Lo
 
 // joinStrings is a helper to join strings with a separator
 func joinStrings(strs []string, sep string) string {
-	if len(strs) == 0 {
-		return ""
-	}
-	result := strs[0]
-	for i := 1; i < len(strs); i++ {
-		result += sep + strs[i]
-	}
-	return result
+	return strings.Join(strs, sep)
 }

--- a/pkg/errors/cache.go
+++ b/pkg/errors/cache.go
@@ -65,8 +65,18 @@ func (c *keywordSuggestionCache) set(input, suggestion string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	// Partial eviction: keep half the entries when max size is reached
-	// This prevents cache thrashing while maintaining performance
+	// Partial eviction: keep half the entries when max size is reached.
+	// This prevents cache thrashing while maintaining performance.
+	//
+	// Note on non-determinism: Go map iteration order is intentionally randomised
+	// by the runtime, so the specific entries copied into newCache are
+	// unpredictable — the eviction effectively removes a random ~50% of entries
+	// rather than the least-recently-used ones.  For a keyword suggestion cache
+	// this is perfectly acceptable: all retained entries are equally valid
+	// suggestions, and the cost of a cache miss is only a Levenshtein distance
+	// calculation.  Adding a true LRU eviction policy (e.g., via a doubly-linked
+	// list or separate access-order map) would substantially increase complexity
+	// and lock contention for negligible practical benefit.
 	if len(c.cache) >= c.maxSize {
 		newCache := make(map[string]string, c.maxSize/2)
 		count := 0

--- a/pkg/formatter/formatter.go
+++ b/pkg/formatter/formatter.go
@@ -71,7 +71,8 @@ func (f *Formatter) Format(sql string) (string, error) {
 	// Capture comments from tokenizer before parsing
 	comments := tkz.Comments
 
-	p := parser.NewParser()
+	p := parser.GetParser()
+	defer parser.PutParser(p)
 	parsedAST, err := p.ParseFromModelTokens(tokens)
 	if err != nil {
 		return "", fmt.Errorf("parsing failed: %w", err)

--- a/pkg/sql/parser/parser.go
+++ b/pkg/sql/parser/parser.go
@@ -158,7 +158,7 @@ func PutParser(p *Parser) {
 
 // Reset clears the parser state for reuse from the pool.
 func (p *Parser) Reset() {
-	p.tokens = nil
+	p.tokens = p.tokens[:0]
 	p.currentPos = 0
 	p.currentToken = models.TokenWithSpan{}
 	p.depth = 0
@@ -739,6 +739,8 @@ func (p *Parser) advance() {
 	p.currentPos++
 	if p.currentPos < len(p.tokens) {
 		p.currentToken = p.tokens[p.currentPos]
+	} else {
+		p.currentToken = models.TokenWithSpan{} // EOF sentinel
 	}
 }
 

--- a/pkg/sql/parser/select_clauses.go
+++ b/pkg/sql/parser/select_clauses.go
@@ -34,6 +34,30 @@ import (
 func (p *Parser) parseFromClause() (tableName string, tables []ast.TableReference, joins []ast.JoinClause, err error) {
 	// FROM is optional (e.g. SELECT 1).  Validate that the next token makes sense.
 	if !p.isType(models.TokenTypeFrom) {
+		// advance() sets a zero-value sentinel (TokenType == TokenTypeEOF == 0) when
+		// currentPos goes past the end of the token slice.  A real EOF token produced by
+		// the tokenizer is also TokenTypeEOF but is still within the slice.
+		// To replicate the correct behaviour we need to know what the last consumed token
+		// was: e.g. SELECT (1,2,3) ends with ')' (FROM is optional) while SELECT *
+		// ends with '*' (FROM is required).  When currentPos is past the slice end,
+		// inspect the last real token directly instead of relying on currentToken.
+		if p.currentPos >= len(p.tokens) {
+			// Past end of token stream — check whether the last real token implies
+			// that FROM can legitimately be omitted.
+			if len(p.tokens) > 0 {
+				lastTokType := p.tokens[len(p.tokens)-1].Token.Type
+				if lastTokType == models.TokenTypeSemicolon ||
+					lastTokType == models.TokenTypeRParen ||
+					lastTokType == models.TokenTypeEOF ||
+					lastTokType == models.TokenTypeUnion ||
+					lastTokType == models.TokenTypeExcept ||
+					lastTokType == models.TokenTypeIntersect {
+					return "", nil, nil, nil
+				}
+			}
+			return "", nil, nil, p.expectedError("FROM, semicolon, or end of statement")
+		}
+		// Current token is still within the slice — use the normal token-type check.
 		if !p.isType(models.TokenTypeEOF) &&
 			!p.isType(models.TokenTypeSemicolon) &&
 			!p.isType(models.TokenTypeRParen) &&

--- a/pkg/sql/security/scanner.go
+++ b/pkg/sql/security/scanner.go
@@ -294,6 +294,17 @@ func initCommentPatterns() {
 	}
 }
 
+// maxRegexInputLen guards against ReDoS by limiting the input length
+// fed to regexes with nested quantifiers (e.g. the block-comment pattern).
+const maxRegexInputLen = 10_000
+
+func safeRegexMatch(re *regexp.Regexp, s string) bool {
+	if len(s) > maxRegexInputLen {
+		s = s[:maxRegexInputLen]
+	}
+	return re.MatchString(s)
+}
+
 // System table prefixes for precise matching (avoids false positives)
 var systemTablePrefixes = []string{
 	"information_schema.",
@@ -919,7 +930,7 @@ func (s *Scanner) detectCommentPatterns(sql string, result *ScanResult) {
 	commentPatternsOnce.Do(initCommentPatterns)
 
 	for _, p := range commentPatterns {
-		if p.re.MatchString(sql) {
+		if safeRegexMatch(p.re, sql) {
 			finding := Finding{
 				Severity:    p.severity,
 				Pattern:     PatternComment,

--- a/pkg/sql/tokenizer/pool.go
+++ b/pkg/sql/tokenizer/pool.go
@@ -57,7 +57,10 @@ func putBuffer(buf *bytes.Buffer) {
 //   - Zero-allocation instance reuse when pool is warm
 var tokenizerPool = sync.Pool{
 	New: func() interface{} {
-		t, _ := New() // Error ignored as New() only errors on keyword initialization
+		t, err := New()
+		if err != nil {
+			panic("gosqlx: failed to initialize tokenizer pool: " + err.Error())
+		}
 		return t
 	},
 }

--- a/pkg/sql/tokenizer/tokenizer.go
+++ b/pkg/sql/tokenizer/tokenizer.go
@@ -1366,6 +1366,7 @@ func (t *Tokenizer) readPunctuation() (models.Token, error) {
 				commentStartPos := t.toSQLPosition(Position{Index: commentStartIdx})
 				t.pos.AdvanceRune(nxtR, nxtSize)
 				// Skip until */ or EOF
+				closed := false
 				for t.pos.Index < len(t.input) {
 					cr, csize := utf8.DecodeRune(t.input[t.pos.Index:])
 					if cr == '*' {
@@ -1374,12 +1375,19 @@ func (t *Tokenizer) readPunctuation() (models.Token, error) {
 							nr, ns := utf8.DecodeRune(t.input[t.pos.Index:])
 							if nr == '/' {
 								t.pos.AdvanceRune(nr, ns) // End of block comment
+								closed = true
 								break
 							}
 						}
 					} else {
 						t.pos.AdvanceRune(cr, csize)
 					}
+				}
+				if !closed {
+					return models.Token{}, errors.UnterminatedStringError(
+						commentStartPos,
+						string(t.input),
+					)
 				}
 				t.Comments = append(t.Comments, models.Comment{
 					Text:   string(t.input[commentStartIdx:t.pos.Index]),


### PR DESCRIPTION
## Summary

Fixes confirmed bugs and robustness gaps identified by five review agents (Software Architect, QA, Monkey Testing, UAT, Code Review) across five packages:

- **tokenizer/pool.go** (A1): `sync.Pool` `New()` now panics with a meaningful message instead of silently inserting `nil` when `New()` fails, preventing a confusing nil-pointer panic deep in call stacks
- **tokenizer/tokenizer.go** (A2): Unterminated block comment (`/* ...` with no closing `*/`) now returns an `UnterminatedStringError` at the comment start position instead of silently consuming input to EOF
- **parser/parser.go** (B1, B2): `Reset()` uses `tokens[:0]` to preserve pre-allocated capacity; `advance()` now sets a zero-value `TokenWithSpan{}` EOF sentinel instead of leaving a stale token value when past the end of the token slice
- **parser/select_clauses.go**: Companion fix for B2 — `parseFromClause` correctly handles both in-slice and past-end positions after the EOF sentinel change
- **errors/builders.go** (C1): `joinStrings()` replaced O(n²) string concatenation loop with `strings.Join`
- **errors/cache.go** (C2): Documents the intentional random ~50% eviction trade-off vs LRU complexity
- **formatter/formatter.go** (D1): `Format()` now uses `GetParser()`/`PutParser()` pool instead of allocating a fresh parser on every call
- **security/scanner.go** (E1): `safeRegexMatch()` helper truncates input to 10KB before applying the block comment regex (which has nested quantifiers) to bound worst-case ReDoS backtracking

## Test plan

- [ ] `go test -race -timeout 120s ./...` — all 47 packages pass, zero race conditions
- [ ] Pre-commit hooks (fmt, vet, short tests) — all passed before commit
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)