### PR TITLE
docs: release v1.9.2 — version bumps, changelog, and documentation updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to GoSQLX will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.9.2] - 2026-03-08 — Documentation, Community Health & License Fixes
+
+### 📚 Documentation (PR #351)
+- Fix pkg.go.dev license detection (Apache-2.0 now properly detected)
+- Comprehensive doc improvements across the project
+
+### 🌍 Community (PR #350)
+- Open-source health files (CONTRIBUTING.md, CODE_OF_CONDUCT.md, SECURITY.md, etc.)
+- LLM discovery metadata (llms.txt, llms-full.txt)
+- SEO improvements for project discoverability
+
+### 🐛 Bug Fixes (PR #352)
+- Fix leading blank line in vscode-extension/LICENSE
+
+---
+
 ## [1.9.0] - 2026-02-28 - SQLite PRAGMA, Tautology Detection & 19 Post-UAT Fixes
 
 19 actionable bugs fixed (PR #348) — 3 new capabilities, 8 parser fixes,

--- a/cmd/gosqlx/cmd/root.go
+++ b/cmd/gosqlx/cmd/root.go
@@ -28,20 +28,14 @@ import (
 // This version tracks feature releases and compatibility.
 // Format: MAJOR.MINOR.PATCH (Semantic Versioning 2.0.0)
 //
-// Version 1.9.0 includes:
-//   - SQLite PRAGMA fully parsed (bare, arg, and assignment forms)
-//   - WITHOUT ROWID support in CREATE TABLE
-//   - Tautology injection detection (1=1, 'a'='a', OR TRUE) → CRITICAL
-//   - UNION false-positive fix: PatternUnionInjection (CRITICAL) / PatternUnionGeneric (HIGH)
-//   - E1009 ErrCodeUnterminatedBlockComment for /* ... */ errors
-//   - MySQL backtick and SQL Server bracket reserved-word identifiers
-//   - KEY/INDEX/VIEW reserved keywords valid in qualified identifiers
-//   - NATURAL JOIN type stored correctly
-//   - OVER <window_name> (bare name, no parens) per SQL:2003 §7.11
-//   - token_count, Query Size, CTE output, SELECT indentation fixes
-//   - lint exits 1 on any violation (usable as CI gate)
-//   - validate output standardized to ✅/❌
-var Version = "1.9.0"
+// Version 1.9.2 includes:
+//   - Fix pkg.go.dev license detection (Apache-2.0 now properly detected)
+//   - Comprehensive doc improvements across the project (PR #351)
+//   - Open-source health files (CONTRIBUTING.md, CODE_OF_CONDUCT.md, SECURITY.md)
+//   - LLM discovery metadata (llms.txt, llms-full.txt) (PR #350)
+//   - SEO improvements for project discoverability
+//   - Fix leading blank line in vscode-extension/LICENSE (PR #352)
+var Version = "1.9.2"
 
 var (
 	// verbose enables detailed output for debugging and troubleshooting.

--- a/pkg/gosqlx/gosqlx.go
+++ b/pkg/gosqlx/gosqlx.go
@@ -28,7 +28,7 @@ import (
 )
 
 // Version is the current GoSQLX library version.
-const Version = "1.9.0"
+const Version = "1.9.2"
 
 // Parse tokenizes and parses SQL in one call, returning an Abstract Syntax Tree (AST).
 //


### PR DESCRIPTION
## Release v1.9.2

### Changes since v1.9.0:
- **PR #351**: pkg.go.dev license detection fix + comprehensive doc improvements
- **PR #350**: Open-source health files, LLM discovery, SEO improvements  
- **PR #352**: Fix leading blank line in vscode-extension/LICENSE

### Release checklist:
- [x] Version bumped in `pkg/gosqlx/gosqlx.go`
- [x] Version bumped in `cmd/gosqlx/cmd/root.go`
- [x] CHANGELOG.md updated
- [x] CI green