### PR TITLE
fix: update remaining 1.9.0 version references to 1.9.2

### DIFF
--- a/cmd/gosqlx/cmd/doc.go
+++ b/cmd/gosqlx/cmd/doc.go
@@ -341,7 +341,7 @@
 //
 // Version information:
 //
-//	Version = "1.9.0" - Current CLI version
+//	Version = "1.9.2" - Current CLI version
 //
 // # Dependencies
 //

--- a/pkg/cbinding/cbinding.go
+++ b/pkg/cbinding/cbinding.go
@@ -35,7 +35,7 @@
 //	gosqlx_extract_columns(sql)   — extract referenced column names as JSON array
 //	gosqlx_extract_functions(sql) — extract referenced function names as JSON array
 //	gosqlx_extract_metadata(sql)  — extract tables, columns, functions with schema qualification
-//	gosqlx_version()              — return the library version string (e.g. "1.9.0")
+//	gosqlx_version()              — return the library version string (e.g. "1.9.2")
 //	gosqlx_free(ptr)              — free a string previously returned by any gosqlx_* function
 package main
 


### PR DESCRIPTION
Updates the last two `1.9.0` references to `1.9.2` for complete version consistency:

- `cmd/gosqlx/cmd/doc.go:344` — version comment in doc block
- `pkg/cbinding/cbinding.go:38` — example version in C binding doc comment

After this, `grep -rn '"1.9.0"' --include='*.go'` returns zero results.