### PR TITLE
docs: release v1.9.3 — version bumps and changelog for license detection fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to GoSQLX will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.9.3] - 2026-03-08 — License Detection Fix
+
+### 🐛 Bug Fixes
+- Replace LICENSE files with exact official Apache 2.0 text for pkg.go.dev detection (PR #356)
+- Fix cobra command version string consistency (PR #354)
+- Fix remaining 1.9.0 version references in doc comments (PR #355)
+
+### 📝 Note
+v1.9.2 was cached by the Go module proxy before the LICENSE fix landed,
+so pkg.go.dev could not detect the license. This release ensures the
+corrected LICENSE is served for `go get` users.
+
+---
+
 ## [1.9.2] - 2026-03-08 — Documentation, Community Health & License Fixes
 
 ### 📚 Documentation (PR #351)

--- a/cmd/gosqlx/cmd/doc.go
+++ b/cmd/gosqlx/cmd/doc.go
@@ -341,7 +341,7 @@
 //
 // Version information:
 //
-//	Version = "1.9.2" - Current CLI version
+//	Version = "1.9.3" - Current CLI version
 //
 // # Dependencies
 //

--- a/cmd/gosqlx/cmd/root.go
+++ b/cmd/gosqlx/cmd/root.go
@@ -28,14 +28,14 @@ import (
 // This version tracks feature releases and compatibility.
 // Format: MAJOR.MINOR.PATCH (Semantic Versioning 2.0.0)
 //
-// Version 1.9.2 includes:
+// Version 1.9.3 includes:
 //   - Fix pkg.go.dev license detection (Apache-2.0 now properly detected)
 //   - Comprehensive doc improvements across the project (PR #351)
 //   - Open-source health files (CONTRIBUTING.md, CODE_OF_CONDUCT.md, SECURITY.md)
 //   - LLM discovery metadata (llms.txt, llms-full.txt) (PR #350)
 //   - SEO improvements for project discoverability
 //   - Fix leading blank line in vscode-extension/LICENSE (PR #352)
-var Version = "1.9.2"
+var Version = "1.9.3"
 
 var (
 	// verbose enables detailed output for debugging and troubleshooting.
@@ -123,7 +123,7 @@ Key features:
 • CI/CD integration with proper exit codes
 
 Performance: 1.5M+ operations/second sustained, 1.97M peak. 100-1000x faster than competitors.`,
-	Version: "1.9.2",
+	Version: "1.9.3",
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.

--- a/pkg/cbinding/cbinding.go
+++ b/pkg/cbinding/cbinding.go
@@ -35,7 +35,7 @@
 //	gosqlx_extract_columns(sql)   — extract referenced column names as JSON array
 //	gosqlx_extract_functions(sql) — extract referenced function names as JSON array
 //	gosqlx_extract_metadata(sql)  — extract tables, columns, functions with schema qualification
-//	gosqlx_version()              — return the library version string (e.g. "1.9.2")
+//	gosqlx_version()              — return the library version string (e.g. "1.9.3")
 //	gosqlx_free(ptr)              — free a string previously returned by any gosqlx_* function
 package main
 

--- a/pkg/gosqlx/gosqlx.go
+++ b/pkg/gosqlx/gosqlx.go
@@ -28,7 +28,7 @@ import (
 )
 
 // Version is the current GoSQLX library version.
-const Version = "1.9.2"
+const Version = "1.9.3"
 
 // Parse tokenizes and parses SQL in one call, returning an Abstract Syntax Tree (AST).
 //


### PR DESCRIPTION
## Why v1.9.3?

v1.9.2 was cached by the Go module proxy **before** PR #356 (LICENSE fix) landed. Re-tagging doesn't update the proxy's immutable cache, so pkg.go.dev still shows `License: UNKNOWN`.

This release bumps to v1.9.3 so the proxy fetches a fresh zip with the corrected official Apache 2.0 LICENSE text.

### Changes
- Version bumped to 1.9.3 in all 5 locations
- CHANGELOG.md updated with v1.9.3 entry

### Release checklist
- [x] Version bumped in `pkg/gosqlx/gosqlx.go`
- [x] Version bumped in `cmd/gosqlx/cmd/root.go` (var + cobra + comment)
- [x] Version bumped in `cmd/gosqlx/cmd/doc.go`
- [x] Version bumped in `pkg/cbinding/cbinding.go`
- [x] CHANGELOG.md updated