### PR TITLE
docs: release v1.10.0 — MCP Server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to GoSQLX will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] — MCP Server
+## [1.10.0] - 2026-03-13 — MCP Server
 
 ### ✨ New Features
 - **MCP Server** (`pkg/mcp/`, `cmd/gosqlx-mcp/`): All GoSQLX SQL capabilities as Model Context Protocol tools over streamable HTTP

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ GoSQLX is a **production-ready**, **race-free**, high-performance SQL parsing SD
 
 **Requirements**: Go 1.23+ (upgraded from 1.21 when MCP server was added; `mark3labs/mcp-go` requires 1.23)
 
-**Production Status**: ✅ Validated for production deployment (v1.6.0+, current: v1.9.0)
+**Production Status**: ✅ Validated for production deployment (v1.6.0+, current: v1.10.0)
 - Thread-safe with zero race conditions (20,000+ concurrent operations tested)
 - 1.38M+ ops/sec sustained, 1.5M peak with memory-efficient object pooling
 - ~80-85% SQL-99 compliance (window functions, CTEs, set operations, MERGE, etc.)

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ GoSQLX is a high-performance SQL parsing library designed for production use. It
 - **MCP Server** (v1.10.0): `gosqlx-mcp` exposes all 7 SQL tools as [Model Context Protocol](https://modelcontextprotocol.io) tools over streamable HTTP — integrate GoSQLX into Claude, Cursor, and any MCP-compatible AI assistant
 - **Production Ready**: Battle-tested with 0 race conditions detected, ~85% SQL-99 compliance, Apache-2.0 licensed
 
-### Performance & Quality Highlights (v1.9.0)
+### Performance & Quality Highlights (v1.10.0)
 
 <div align="center">
 
@@ -76,26 +76,24 @@ GoSQLX is a high-performance SQL parsing library designed for production use. It
 |:---------:|:-------:|:----------:|:----------:|:-------:|:---------:|
 | Faster Parsing | Peak Ops/sec | Latency | SQL Dialects | Parser Coverage | New Commits |
 
-**v1.9.0 Released** • **SQLite PRAGMA** • **Tautology Detection** • **19 Post-UAT Fixes** • **lint CI-gate** • **UNION false-positive fix**
+**v1.10.0 Released** • **MCP Server** • **7 AI-Ready SQL Tools** • **Streamable HTTP** • **Bearer Auth** • **Go 1.23+**
 
 </div>
 
-### What's New in v1.9.0
+### What's New in v1.10.0
 
 <div align="center">
 
 | Feature | Description |
 |---------|-------------|
-| **SQLite PRAGMA** | Fully parsed: bare (`PRAGMA x`), arg (`PRAGMA x(n)`), assignment (`PRAGMA x=v`) forms |
-| **WITHOUT ROWID** | SQLite `CREATE TABLE ... WITHOUT ROWID`; reserved keywords valid as DDL column names |
-| **Tautology Detection** | `ScanSQL()` detects `1=1`, `'a'='a'`, `col=col`, `OR TRUE` → CRITICAL severity |
-| **UNION False-positive Fix** | `PatternUnionInjection` (CRITICAL, system tables) vs `PatternUnionGeneric` (HIGH) |
-| **lint CI-gate** | `gosqlx lint` now exits 1 on any violation — usable in CI pipelines without `--fail-on-warn` |
-| **CLI Output Fixes** | token_count, Query Size, CTE output, SELECT indentation, ✅/❌ validate output all corrected |
-| **Parser Fixes** | KEY/INDEX in qualified names, NATURAL JOIN type, OVER window_name, backtick/bracket identifiers |
-| **E1009** | Dedicated error code `ErrCodeUnterminatedBlockComment` for unterminated `/* ... */` comments |
+| **MCP Server** | All GoSQLX SQL capabilities as [Model Context Protocol](https://modelcontextprotocol.io) tools over streamable HTTP |
+| **7 MCP Tools** | `validate_sql`, `format_sql`, `parse_sql`, `extract_metadata`, `security_scan`, `lint_sql`, `analyze_sql` |
+| **Bearer Auth** | Optional authentication via `GOSQLX_MCP_AUTH_TOKEN` environment variable |
+| **Concurrent Analysis** | `analyze_sql` fans out all 6 tools concurrently via `sync.WaitGroup` |
+| **Multi-Dialect MCP** | Validate against postgresql, mysql, sqlite, sqlserver, oracle, snowflake, or generic |
+| **Go 1.23+** | Minimum Go version bumped to 1.23.0 (required by `mark3labs/mcp-go`) |
 
-See [CHANGELOG.md](CHANGELOG.md) for the complete list of 19 fixes in this release.
+See [CHANGELOG.md](CHANGELOG.md) for the complete release details. See [MCP_GUIDE.md](docs/MCP_GUIDE.md) for setup instructions.
 
 </div>
 

--- a/cmd/gosqlx/cmd/doc.go
+++ b/cmd/gosqlx/cmd/doc.go
@@ -341,7 +341,7 @@
 //
 // Version information:
 //
-//	Version = "1.9.3" - Current CLI version
+//	Version = "1.10.0" - Current CLI version
 //
 // # Dependencies
 //

--- a/cmd/gosqlx/cmd/root.go
+++ b/cmd/gosqlx/cmd/root.go
@@ -28,14 +28,12 @@ import (
 // This version tracks feature releases and compatibility.
 // Format: MAJOR.MINOR.PATCH (Semantic Versioning 2.0.0)
 //
-// Version 1.9.3 includes:
-//   - Fix pkg.go.dev license detection (Apache-2.0 now properly detected)
-//   - Comprehensive doc improvements across the project (PR #351)
-//   - Open-source health files (CONTRIBUTING.md, CODE_OF_CONDUCT.md, SECURITY.md)
-//   - LLM discovery metadata (llms.txt, llms-full.txt) (PR #350)
-//   - SEO improvements for project discoverability
-//   - Fix leading blank line in vscode-extension/LICENSE (PR #352)
-var Version = "1.9.3"
+// Version 1.10.0 includes:
+//   - MCP Server: All GoSQLX SQL capabilities as Model Context Protocol tools over streamable HTTP
+//   - 7 MCP tools: validate_sql, format_sql, parse_sql, extract_metadata, security_scan, lint_sql, analyze_sql
+//   - Optional bearer token auth via GOSQLX_MCP_AUTH_TOKEN
+//   - Go minimum bumped to 1.23.0 (required by mark3labs/mcp-go)
+var Version = "1.10.0"
 
 var (
 	// verbose enables detailed output for debugging and troubleshooting.
@@ -123,7 +121,7 @@ Key features:
 • CI/CD integration with proper exit codes
 
 Performance: 1.5M+ operations/second sustained, 1.97M peak. 100-1000x faster than competitors.`,
-	Version: "1.9.3",
+	Version: "1.10.0",
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.

--- a/cmd/gosqlx/doc.go
+++ b/cmd/gosqlx/doc.go
@@ -24,7 +24,7 @@
 //
 // # Version
 //
-// Current version: 1.9.0
+// Current version: 1.10.0
 //
 // # Architecture
 //

--- a/doc.go
+++ b/doc.go
@@ -16,7 +16,7 @@
 // zero-copy tokenization and comprehensive object pooling. It offers enterprise-grade SQL lexing,
 // parsing, and AST generation with support for multiple SQL dialects and advanced SQL features.
 //
-// GoSQLX v1.9.0 includes both a powerful Go SDK and a high-performance CLI tool for SQL processing,
+// GoSQLX v1.10.0 includes both a powerful Go SDK and a high-performance CLI tool for SQL processing,
 // validated for production deployment with race-free concurrent operation and extensive real-world testing.
 //
 // Production Status: VALIDATED FOR PRODUCTION DEPLOYMENT (v1.6.0+)
@@ -278,6 +278,9 @@
 //
 // # Version History
 //
+// v1.10.0: MCP Server — all SQL tools as Model Context Protocol tools over streamable HTTP
+// v1.9.0: SQLite PRAGMA, tautology detection, 19 post-UAT fixes
+// v1.8.0: Multi-dialect engine, query transforms, WASM playground, AST-to-SQL roundtrip
 // v1.6.0: PostgreSQL extensions (LATERAL, JSON operators, DISTINCT ON, FILTER, RETURNING)
 // v1.5.0: GROUPING SETS, ROLLUP, CUBE, MERGE statements, materialized views
 // v1.4.0: Window functions with PARTITION BY, ORDER BY, frame clauses

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -1,4 +1,4 @@
-# GoSQLX API Reference (v1.9.0)
+# GoSQLX API Reference (v1.10.0)
 
 ## Table of Contents
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # GoSQLX Architecture Documentation
 
-**Version**: v1.9.0
-**Last Updated**: 2026-02-28
+**Version**: v1.10.0
+**Last Updated**: 2026-03-13
 
 ## Table of Contents
 - [System Overview](#system-overview)

--- a/docs/CLI_GUIDE.md
+++ b/docs/CLI_GUIDE.md
@@ -1,7 +1,7 @@
 # GoSQLX CLI Guide
 
-**Version**: v1.9.0
-**Last Updated**: 2026-02-28
+**Version**: v1.10.0
+**Last Updated**: 2026-03-13
 
 The GoSQLX Command Line Interface (CLI) provides high-performance SQL parsing, validation, formatting, and analysis capabilities directly from your terminal.
 

--- a/docs/ERROR_CODES.md
+++ b/docs/ERROR_CODES.md
@@ -1,7 +1,7 @@
 # GoSQLX Error Codes Reference
 
-**Version**: v1.9.0
-**Last Updated**: 2026-02-28
+**Version**: v1.10.0
+**Last Updated**: 2026-03-13
 
 Comprehensive reference for all error codes in GoSQLX with examples and solutions.
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -2,12 +2,11 @@
 
 Welcome! This guide will get you parsing SQL in under 5 minutes. No prior experience with GoSQLX required.
 
-**What's New in v1.9.0:**
-- SQLite PRAGMA fully parsed (bare, arg, and assignment forms)
-- Tautology injection detection (`1=1`, `'a'='a'`, `OR TRUE`) → CRITICAL severity
-- UNION false-positive fix: `PatternUnionInjection` (CRITICAL) vs `PatternUnionGeneric` (HIGH)
-- `gosqlx lint` exits 1 on any violation — usable as CI gate without extra flags
-- `E1009` dedicated error code for unterminated `/* ... */` block comments
+**What's New in v1.10.0:**
+- **MCP Server**: All GoSQLX SQL capabilities as Model Context Protocol tools over streamable HTTP
+- 7 MCP tools: `validate_sql`, `format_sql`, `parse_sql`, `extract_metadata`, `security_scan`, `lint_sql`, `analyze_sql`
+- Optional bearer token auth via `GOSQLX_MCP_AUTH_TOKEN`
+- Go minimum bumped to 1.23.0 (required by `mark3labs/mcp-go`)
 - 19 post-UAT fixes: parser, CLI output, security scanner (see CHANGELOG for full list)
 - Enhanced SQL-99 compliance with NULLS FIRST/LAST ordering
 
@@ -61,7 +60,7 @@ echo "select * from users where age>18" | gosqlx format
 echo "SELECT COUNT(*) FROM orders GROUP BY status" | gosqlx analyze
 ```
 
-**Available CLI Commands (v1.9.0):**
+**Available CLI Commands (v1.10.0):**
 - `validate` - Ultra-fast SQL validation with security scanning
 - `format` - High-performance SQL formatting with style options
 - `analyze` - Advanced SQL analysis with complexity metrics

--- a/docs/LINTING_RULES.md
+++ b/docs/LINTING_RULES.md
@@ -1,7 +1,7 @@
 # SQL Linting Rules Reference
 
-**Version**: v1.9.0
-**Last Updated**: 2026-02-28
+**Version**: v1.10.0
+**Last Updated**: 2026-03-13
 
 This document provides a complete reference for all GoSQLX SQL linting rules (L001-L010).
 

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -1,5 +1,18 @@
 # Migration Guide
 
+## v1.9.x → v1.10.0 (2026-03-13)
+
+**Go version requirement changed**: Go 1.23+ is now required (was 1.21+). This is due to the `mark3labs/mcp-go` dependency used by the new MCP server. If you only use the parsing SDK (not the MCP server), Go 1.21+ still works, but `go.mod` declares 1.23.
+
+No breaking API changes. Drop-in upgrade for existing code.
+
+### New: MCP Server
+- `pkg/mcp/` — MCP server package with 7 SQL tools
+- `cmd/gosqlx-mcp/` — Standalone MCP server binary
+- See `docs/MCP_GUIDE.md` for usage
+
+---
+
 ## v1.8.0 → v1.9.0 (2026-02-28)
 
 No breaking changes. No API changes. Drop-in upgrade.

--- a/docs/PRODUCTION_GUIDE.md
+++ b/docs/PRODUCTION_GUIDE.md
@@ -1,6 +1,6 @@
 # GoSQLX Production Deployment Guide
 
-**Version**: v1.9.0 | **Last Updated**: 2026-02-28
+**Version**: v1.10.0 | **Last Updated**: 2026-03-13
 
 Comprehensive guide for deploying GoSQLX in production environments.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,9 +2,9 @@
 
 Comprehensive documentation for the GoSQLX SQL parsing SDK.
 
-**Current Version**: v1.9.0 | **Last Updated**: 2026-02-28
+**Current Version**: v1.10.0 | **Last Updated**: 2026-03-13
 
-## Feature Overview (v1.9.0)
+## Feature Overview (v1.10.0)
 
 GoSQLX is a production-ready, high-performance SQL parsing SDK for Go with comprehensive feature support:
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -5,7 +5,7 @@ This document provides comprehensive security analysis, operational security set
 ## 🛡️ Comprehensive Security Assessment
 
 **Analysis Date**: 2026-02-28
-**Version**: v1.9.0
+**Version**: v1.10.0
 **Security Score**: 9.0/10 ⭐⭐⭐⭐⭐
 
 ---

--- a/docs/SQL_COMPATIBILITY.md
+++ b/docs/SQL_COMPATIBILITY.md
@@ -1,6 +1,6 @@
 # GoSQLX SQL Feature Compatibility Matrix
 
-**Version**: v1.9.0 | **Last Updated**: 2026-02-28
+**Version**: v1.10.0 | **Last Updated**: 2026-03-13
 
 ## Overview
 
@@ -599,7 +599,7 @@ gosqlx format --dialect mysql query.sql
 
 ## SQL Standards Compliance Summary
 
-### Overall Compliance (v1.9.0)
+### Overall Compliance (v1.10.0)
 
 | Standard | Compliance % | Status | Notes |
 |----------|--------------|--------|-------|
@@ -789,9 +789,9 @@ gosqlx format --dialect mysql query.sql
 
 ---
 
-**Last Updated**: 2026-02-28
-**GoSQLX Version**: 1.9.0
-**Test Suite Version**: 1.9.0
+**Last Updated**: 2026-03-13
+**GoSQLX Version**: 1.10.0
+**Test Suite Version**: 1.10.0
 **Total Test Cases**: 800+
 **Coverage Percentage**: 95%+
 **SQL-99 Compliance**: ~85%

--- a/docs/USAGE_GUIDE.md
+++ b/docs/USAGE_GUIDE.md
@@ -1,6 +1,6 @@
 # GoSQLX Usage Guide
 
-**Version**: v1.9.0 | **Last Updated**: 2026-02-28
+**Version**: v1.10.0 | **Last Updated**: 2026-03-13
 
 ## Table of Contents
 - [Getting Started](#getting-started)

--- a/llms.txt
+++ b/llms.txt
@@ -7,7 +7,7 @@ recursive-descent parsing, and AST generation with comprehensive object pooling.
 PostgreSQL, MySQL, SQL Server, Oracle, SQLite, and Snowflake dialects, and ships a full-featured
 CLI tool (`gosqlx`) for validation, formatting, linting, and security analysis. Apache-2.0 licensed.
 
-Current stable version: v1.9.0 (2026-02-28)
+Current stable version: v1.10.0 (2026-03-13)
 
 ## Core API
 

--- a/performance_baselines.json
+++ b/performance_baselines.json
@@ -1,6 +1,6 @@
 {
-  "version": "1.9.0",
-  "updated": "2026-02-27",
+  "version": "1.10.0",
+  "updated": "2026-03-13",
   "baselines": {
     "SimpleSelect": {
       "ns_per_op": 700,

--- a/pkg/cbinding/cbinding.go
+++ b/pkg/cbinding/cbinding.go
@@ -35,7 +35,7 @@
 //	gosqlx_extract_columns(sql)   — extract referenced column names as JSON array
 //	gosqlx_extract_functions(sql) — extract referenced function names as JSON array
 //	gosqlx_extract_metadata(sql)  — extract tables, columns, functions with schema qualification
-//	gosqlx_version()              — return the library version string (e.g. "1.9.3")
+//	gosqlx_version()              — return the library version string (e.g. "1.10.0")
 //	gosqlx_free(ptr)              — free a string previously returned by any gosqlx_* function
 package main
 

--- a/pkg/gosqlx/gosqlx.go
+++ b/pkg/gosqlx/gosqlx.go
@@ -28,7 +28,7 @@ import (
 )
 
 // Version is the current GoSQLX library version.
-const Version = "1.9.3"
+const Version = "1.10.0"
 
 // Parse tokenizes and parses SQL in one call, returning an Abstract Syntax Tree (AST).
 //

--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -35,7 +35,7 @@ func New(cfg *Config) *Server {
 	s := &Server{cfg: cfg}
 	s.mcpSrv = mcpserver.NewMCPServer(
 		"gosqlx-mcp",
-		"1.9.3",
+		"1.10.0",
 		mcpserver.WithToolCapabilities(false),
 	)
 	s.registerTools()


### PR DESCRIPTION
## Summary

- Bump version from 1.9.3 to 1.10.0 across **24 files**
- Finalize CHANGELOG.md `[Unreleased]` → `[1.10.0] - 2026-03-13`
- Update all documentation version headers to v1.10.0
- Add v1.9.x → v1.10.0 migration section (Go 1.23+ requirement note)
- Update README highlights to feature MCP Server
- Add v1.10.0 to doc.go version history

## Files Updated

**Go source (7):** `pkg/gosqlx/gosqlx.go`, `pkg/mcp/server.go`, `cmd/gosqlx/cmd/root.go`, `cmd/gosqlx/cmd/doc.go`, `cmd/gosqlx/doc.go`, `doc.go`, `pkg/cbinding/cbinding.go`

**Documentation (13):** `CHANGELOG.md`, `CLAUDE.md`, `README.md`, `docs/API_REFERENCE.md`, `docs/ARCHITECTURE.md`, `docs/CLI_GUIDE.md`, `docs/ERROR_CODES.md`, `docs/GETTING_STARTED.md`, `docs/LINTING_RULES.md`, `docs/MIGRATION.md`, `docs/PRODUCTION_GUIDE.md`, `docs/README.md`, `docs/SECURITY.md`, `docs/SQL_COMPATIBILITY.md`, `docs/USAGE_GUIDE.md`

**Config/metadata (4):** `llms.txt`, `performance_baselines.json`

## Release Steps (after merge)

```bash
git checkout main && git pull
git tag v1.10.0 -a -m "v1.10.0: MCP Server — all SQL tools as Model Context Protocol tools over streamable HTTP"
git push origin v1.10.0
gh release create v1.10.0 --title "v1.10.0: MCP Server" --notes "..."
```

## Test plan

- [x] `go build ./...` compiles cleanly
- [x] `go test -short ./...` passes
- [x] Pre-commit hooks pass (fmt, vet, test)
- [x] No stale 1.9.3 references in Go source
- [x] CHANGELOG [Unreleased] converted to [1.10.0]

🤖 Generated with [Claude Code](https://claude.com/claude-code)