### PR TITLE
fix: shorten action.yml description for Marketplace publishing

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: 'GoSQLX Lint Action'
-description: 'Ultra-fast SQL validation, linting, and formatting for your CI pipeline — 100x faster than SQLFluff. Supports PR annotations, SARIF output, and multi-dialect SQL.'
+description: 'Ultra-fast SQL validation, linting, and formatting for CI — 100x faster than SQLFluff, multi-dialect.'
 author: 'GoSQLX Team'
 
 branding:


### PR DESCRIPTION
## Summary

- Shorten `action.yml` description from 170 to 103 characters
- GitHub Marketplace requires description under 125 characters

**Before:** `Ultra-fast SQL validation, linting, and formatting for your CI pipeline — 100x faster than SQLFluff. Supports PR annotations, SARIF output, and multi-dialect SQL.`

**After:** `Ultra-fast SQL validation, linting, and formatting for CI — 100x faster than SQLFluff, multi-dialect.`

## Context

Publishing GoSQLX GitHub Action to Marketplace blocked by description length validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)