### PR TITLE
fix: correct smoke test command in vscode-publish workflow

### DIFF
--- a/.github/workflows/vscode-publish.yml
+++ b/.github/workflows/vscode-publish.yml
@@ -21,6 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     strategy:
+      fail-fast: false
       matrix:
         include:
           - target: linux-x64
@@ -67,7 +68,7 @@ jobs:
         if: matrix.target == 'linux-x64'
         run: |
           chmod +x vscode-extension/bin/${{ matrix.binary }}
-          ./vscode-extension/bin/${{ matrix.binary }} version
+          ./vscode-extension/bin/${{ matrix.binary }} --version
 
       - name: Setup Node
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary
- Fix smoke test: `gosqlx version` → `gosqlx --version` (CLI uses flag, not subcommand)
- Add `fail-fast: false` so one platform failure doesn't cancel all other builds

## Context
The v1.10.1 publish workflow failed because the smoke test used the wrong command syntax.

🤖 Generated with [Claude Code](https://claude.com/claude-code)