### PR TITLE
fix: accept --stdio flag in LSP server for VS Code compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to GoSQLX will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.10.3] - 2026-03-14 — LSP --stdio compatibility
+
+### Fixed
+- Accept --stdio flag in gosqlx lsp command (required by vscode-languageclient)
+- Allow empty executablePath in config validation (uses bundled binary fallback)
+
 ## [1.10.2] - 2026-03-14 — VS Code Extension Fix
 
 ### Fixed

--- a/cmd/gosqlx/cmd/doc.go
+++ b/cmd/gosqlx/cmd/doc.go
@@ -341,7 +341,7 @@
 //
 // Version information:
 //
-//	Version = "1.10.2" - Current CLI version
+//	Version = "1.10.3" - Current CLI version
 //
 // # Dependencies
 //

--- a/cmd/gosqlx/cmd/root.go
+++ b/cmd/gosqlx/cmd/root.go
@@ -28,12 +28,12 @@ import (
 // This version tracks feature releases and compatibility.
 // Format: MAJOR.MINOR.PATCH (Semantic Versioning 2.0.0)
 //
-// Version 1.10.2 includes:
+// Version 1.10.3 includes:
 //   - MCP Server: All GoSQLX SQL capabilities as Model Context Protocol tools over streamable HTTP
 //   - 7 MCP tools: validate_sql, format_sql, parse_sql, extract_metadata, security_scan, lint_sql, analyze_sql
 //   - Optional bearer token auth via GOSQLX_MCP_AUTH_TOKEN
 //   - Go minimum bumped to 1.23.0 (required by mark3labs/mcp-go)
-var Version = "1.10.2"
+var Version = "1.10.3"
 
 var (
 	// verbose enables detailed output for debugging and troubleshooting.
@@ -121,7 +121,7 @@ Key features:
 • CI/CD integration with proper exit codes
 
 Performance: 1.5M+ operations/second sustained, 1.97M peak. 100-1000x faster than competitors.`,
-	Version: "1.10.2",
+	Version: "1.10.3",
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.

--- a/cmd/gosqlx/doc.go
+++ b/cmd/gosqlx/doc.go
@@ -24,7 +24,7 @@
 //
 // # Version
 //
-// Current version: 1.10.2
+// Current version: 1.10.3
 //
 // # Architecture
 //

--- a/cmd/gosqlx/internal/lspcmd/lsp.go
+++ b/cmd/gosqlx/internal/lspcmd/lsp.go
@@ -28,6 +28,7 @@ import (
 
 var (
 	lspLogFile string
+	lspStdio   bool
 )
 
 // NewCmd returns the lsp cobra.Command.
@@ -77,6 +78,7 @@ Emacs Integration (lsp-mode):
 	}
 
 	cmd.Flags().StringVar(&lspLogFile, "log", "", "Log file path (optional, for debugging)")
+	cmd.Flags().BoolVar(&lspStdio, "stdio", false, "Use stdio transport (default, accepted for compatibility with vscode-languageclient)")
 
 	return cmd
 }

--- a/doc.go
+++ b/doc.go
@@ -16,7 +16,7 @@
 // zero-copy tokenization and comprehensive object pooling. It offers enterprise-grade SQL lexing,
 // parsing, and AST generation with support for multiple SQL dialects and advanced SQL features.
 //
-// GoSQLX v1.10.2 includes both a powerful Go SDK and a high-performance CLI tool for SQL processing,
+// GoSQLX v1.10.3 includes both a powerful Go SDK and a high-performance CLI tool for SQL processing,
 // validated for production deployment with race-free concurrent operation and extensive real-world testing.
 //
 // Production Status: VALIDATED FOR PRODUCTION DEPLOYMENT (v1.6.0+)
@@ -278,7 +278,7 @@
 //
 // # Version History
 //
-// v1.10.2: VS Code Marketplace publishing with bundled platform-specific binaries
+// v1.10.3: VS Code Marketplace publishing with bundled platform-specific binaries
 // v1.10.0: MCP Server — all SQL tools as Model Context Protocol tools over streamable HTTP
 // v1.9.0: SQLite PRAGMA, tautology detection, 19 post-UAT fixes
 // v1.8.0: Multi-dialect engine, query transforms, WASM playground, AST-to-SQL roundtrip

--- a/llms.txt
+++ b/llms.txt
@@ -7,7 +7,7 @@ recursive-descent parsing, and AST generation with comprehensive object pooling.
 PostgreSQL, MySQL, SQL Server, Oracle, SQLite, and Snowflake dialects, and ships a full-featured
 CLI tool (`gosqlx`) for validation, formatting, linting, and security analysis. Apache-2.0 licensed.
 
-Current stable version: v1.10.2 (2026-03-13)
+Current stable version: v1.10.3 (2026-03-13)
 
 ## Core API
 

--- a/performance_baselines.json
+++ b/performance_baselines.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.10.2",
+  "version": "1.10.3",
   "updated": "2026-03-13",
   "baselines": {
     "SimpleSelect": {

--- a/pkg/gosqlx/gosqlx.go
+++ b/pkg/gosqlx/gosqlx.go
@@ -28,7 +28,7 @@ import (
 )
 
 // Version is the current GoSQLX library version.
-const Version = "1.10.2"
+const Version = "1.10.3"
 
 // Parse tokenizes and parses SQL in one call, returning an Abstract Syntax Tree (AST).
 //

--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -35,7 +35,7 @@ func New(cfg *Config) *Server {
 	s := &Server{cfg: cfg}
 	s.mcpSrv = mcpserver.NewMCPServer(
 		"gosqlx-mcp",
-		"1.10.2",
+		"1.10.3",
 		mcpserver.WithToolCapabilities(false),
 	)
 	s.registerTools()

--- a/vscode-extension/CHANGELOG.md
+++ b/vscode-extension/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the "GoSQLX" extension will be documented in this file.
 
+## [1.10.3] - 2026-03-14
+
+### Fixed
+- LSP server now accepts --stdio flag from vscode-languageclient
+- Empty executablePath no longer triggers validation warning
+
 ## [1.10.2] - 2026-03-14
 
 ### Fixed

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gosqlx",
-  "version": "1.10.2",
+  "version": "1.10.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "gosqlx",
   "displayName": "GoSQLX",
   "description": "High-performance SQL parsing, validation, formatting, and analysis powered by GoSQLX",
-  "version": "1.10.2",
+  "version": "1.10.3",
   "publisher": "ajitpratap0",
   "license": "Apache-2.0",
   "repository": {

--- a/vscode-extension/src/test/unit/commands.test.ts
+++ b/vscode-extension/src/test/unit/commands.test.ts
@@ -357,8 +357,8 @@ function validateDialect(dialect: string): ValidationResult {
 }
 
 function validateExecutablePath(path: string): ValidationResult {
-    if (!path || path.trim().length === 0) {
-        return { valid: false, message: 'Executable path cannot be empty' };
+    if (typeof path !== 'string') {
+        return { valid: false, message: 'Executable path must be a string' };
     }
     return { valid: true };
 }

--- a/vscode-extension/src/test/unit/validation.test.ts
+++ b/vscode-extension/src/test/unit/validation.test.ts
@@ -226,10 +226,9 @@ suite('Executable Path Validation Edge Cases', () => {
         assert.strictEqual(result.valid, true);
     });
 
-    test('should reject empty string', () => {
+    test('should accept empty string (uses bundled binary or PATH fallback)', () => {
         const result = validateExecutablePath('');
-        assert.strictEqual(result.valid, false);
-        assert.ok(result.message?.includes('empty'));
+        assert.strictEqual(result.valid, true);
     });
 
     test('should reject whitespace-only string', () => {
@@ -637,12 +636,9 @@ function validateExecutablePath(execPath: unknown): ValidationResult {
 
     const trimmed = execPath.trim();
 
+    // Empty string is valid — means "use bundled binary or PATH fallback"
     if (trimmed.length === 0) {
-        return {
-            valid: false,
-            message: 'Executable path cannot be empty',
-            suggestion: 'Set to "gosqlx" to use PATH lookup'
-        };
+        return { valid: true };
     }
 
     if (trimmed.includes('  ') || trimmed.includes('\n') || trimmed.includes('\t')) {

--- a/vscode-extension/src/utils/validation.ts
+++ b/vscode-extension/src/utils/validation.ts
@@ -89,12 +89,9 @@ export function validateExecutablePath(execPath: unknown): ValidationResult {
 
     const trimmed = execPath.trim();
 
+    // Empty string is valid — means "use bundled binary or PATH fallback"
     if (trimmed.length === 0) {
-        return {
-            valid: false,
-            message: 'Executable path cannot be empty',
-            suggestion: 'Set to "gosqlx" to use PATH lookup, or provide full path'
-        };
+        return { valid: true };
     }
 
     // Check for suspicious characters that might indicate a typo


### PR DESCRIPTION
## Summary
- Add `--stdio` flag to `gosqlx lsp` command (no-op, accepted for compatibility with vscode-languageclient)
- Fix config validation: empty `executablePath` is now valid (means "use bundled binary or PATH fallback")
- Bump version to 1.10.3

## Problem
The VS Code extension crashed on startup because `vscode-languageclient` passes `--stdio` to the language server binary, but `gosqlx lsp` rejected this unknown flag.

## Test plan
- [x] `gosqlx lsp --stdio` no longer errors
- [x] TypeScript compiles successfully
- [x] Go tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)