### PR TITLE
chore: bump version to 1.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to GoSQLX will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.11.0] - 2026-03-14 — Product Website with WASM Playground
+
+### Added
+- Full product website built with Astro, React, and Tailwind CSS
+- Interactive WASM-powered SQL playground with 4 tabs (AST, Format, Lint, Analyze)
+- Documentation hub rendering 32+ existing markdown docs with sidebar navigation
+- Blog/release notes auto-generated from CHANGELOG.md
+- VS Code extension page with install instructions
+- Benchmarks page with performance data
+- GitHub Actions deployment to GitHub Pages
+- gosqlxAnalyze WASM function for security + optimization analysis
+- Dialect parameter support for all WASM functions
+
 ## [1.10.4] - 2026-03-14 — AST-based LSP Formatting
 
 ### Fixed

--- a/cmd/gosqlx/cmd/doc.go
+++ b/cmd/gosqlx/cmd/doc.go
@@ -341,7 +341,7 @@
 //
 // Version information:
 //
-//	Version = "1.10.4" - Current CLI version
+//	Version = "1.11.0" - Current CLI version
 //
 // # Dependencies
 //

--- a/cmd/gosqlx/cmd/root.go
+++ b/cmd/gosqlx/cmd/root.go
@@ -28,12 +28,12 @@ import (
 // This version tracks feature releases and compatibility.
 // Format: MAJOR.MINOR.PATCH (Semantic Versioning 2.0.0)
 //
-// Version 1.10.4 includes:
+// Version 1.11.0 includes:
 //   - MCP Server: All GoSQLX SQL capabilities as Model Context Protocol tools over streamable HTTP
 //   - 7 MCP tools: validate_sql, format_sql, parse_sql, extract_metadata, security_scan, lint_sql, analyze_sql
 //   - Optional bearer token auth via GOSQLX_MCP_AUTH_TOKEN
 //   - Go minimum bumped to 1.23.0 (required by mark3labs/mcp-go)
-var Version = "1.10.4"
+var Version = "1.11.0"
 
 var (
 	// verbose enables detailed output for debugging and troubleshooting.
@@ -121,7 +121,7 @@ Key features:
 • CI/CD integration with proper exit codes
 
 Performance: 1.5M+ operations/second sustained, 1.97M peak. 100-1000x faster than competitors.`,
-	Version: "1.10.4",
+	Version: "1.11.0",
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.

--- a/cmd/gosqlx/doc.go
+++ b/cmd/gosqlx/doc.go
@@ -24,7 +24,7 @@
 //
 // # Version
 //
-// Current version: 1.10.4
+// Current version: 1.11.0
 //
 // # Architecture
 //

--- a/doc.go
+++ b/doc.go
@@ -16,7 +16,7 @@
 // zero-copy tokenization and comprehensive object pooling. It offers enterprise-grade SQL lexing,
 // parsing, and AST generation with support for multiple SQL dialects and advanced SQL features.
 //
-// GoSQLX v1.10.4 includes both a powerful Go SDK and a high-performance CLI tool for SQL processing,
+// GoSQLX v1.11.0 includes both a powerful Go SDK and a high-performance CLI tool for SQL processing,
 // validated for production deployment with race-free concurrent operation and extensive real-world testing.
 //
 // Production Status: VALIDATED FOR PRODUCTION DEPLOYMENT (v1.6.0+)
@@ -278,7 +278,7 @@
 //
 // # Version History
 //
-// v1.10.4: VS Code Marketplace publishing with bundled platform-specific binaries
+// v1.11.0: VS Code Marketplace publishing with bundled platform-specific binaries
 // v1.10.0: MCP Server — all SQL tools as Model Context Protocol tools over streamable HTTP
 // v1.9.0: SQLite PRAGMA, tautology detection, 19 post-UAT fixes
 // v1.8.0: Multi-dialect engine, query transforms, WASM playground, AST-to-SQL roundtrip

--- a/llms.txt
+++ b/llms.txt
@@ -7,7 +7,7 @@ recursive-descent parsing, and AST generation with comprehensive object pooling.
 PostgreSQL, MySQL, SQL Server, Oracle, SQLite, and Snowflake dialects, and ships a full-featured
 CLI tool (`gosqlx`) for validation, formatting, linting, and security analysis. Apache-2.0 licensed.
 
-Current stable version: v1.10.4 (2026-03-13)
+Current stable version: v1.11.0 (2026-03-13)
 
 ## Core API
 

--- a/performance_baselines.json
+++ b/performance_baselines.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.10.4",
+  "version": "1.11.0",
   "updated": "2026-03-13",
   "baselines": {
     "SimpleSelect": {

--- a/pkg/gosqlx/gosqlx.go
+++ b/pkg/gosqlx/gosqlx.go
@@ -28,7 +28,7 @@ import (
 )
 
 // Version is the current GoSQLX library version.
-const Version = "1.10.4"
+const Version = "1.11.0"
 
 // Parse tokenizes and parses SQL in one call, returning an Abstract Syntax Tree (AST).
 //

--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -35,7 +35,7 @@ func New(cfg *Config) *Server {
 	s := &Server{cfg: cfg}
 	s.mcpSrv = mcpserver.NewMCPServer(
 		"gosqlx-mcp",
-		"1.10.4",
+		"1.11.0",
 		mcpserver.WithToolCapabilities(false),
 	)
 	s.registerTools()

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gosqlx",
-  "version": "1.10.4",
+  "version": "1.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "gosqlx",
   "displayName": "GoSQLX",
   "description": "High-performance SQL parsing, validation, formatting, and analysis powered by GoSQLX",
-  "version": "1.10.4",
+  "version": "1.11.0",
   "publisher": "ajitpratap0",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
## Summary
Version bump to 1.11.0 for the website release.

### What's in v1.11.0
- Product website with WASM-powered SQL playground
- Documentation hub (32+ pages)
- Blog/release notes from CHANGELOG.md
- `gosqlxAnalyze` WASM function
- Dialect parameter support for all WASM functions
- GitHub Actions website deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)