### PR TITLE
fix(website): CSP blocking Astro inline scripts

### DIFF
--- a/website/src/layouts/BaseLayout.astro
+++ b/website/src/layouts/BaseLayout.astro
@@ -29,7 +29,7 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@500;700&family=Instrument+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
     <link rel="dns-prefetch" href="https://img.shields.io">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-eval' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; img-src 'self' https://img.shields.io https://goreportcard.com https://*.shields.io data:; connect-src 'self'">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; img-src 'self' https://img.shields.io https://goreportcard.com https://*.shields.io data:; connect-src 'self'">
     <title>{title}</title>
   </head>
   <body class="min-h-screen flex flex-col">


### PR DESCRIPTION
## Summary
Add `'unsafe-inline'` to CSP `script-src` directive. Astro generates inline `<script>` tags for component hydration and interactive elements (hamburger menu, stats animation, code tabs). The CSP was blocking all 5 inline scripts, breaking site interactivity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)