### PR TITLE
docs: add website references across project files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -232,3 +232,5 @@ Install with: `task hooks:install`
 - `docs/LINTING_RULES.md` - All 10 linting rules reference
 - `docs/SQL_COMPATIBILITY.md` - SQL dialect compatibility matrix
 - `docs/ARCHITECTURE.md` - Detailed system design
+- `https://ajitpratap0.github.io/GoSQLX/` - Official website with interactive playground
+- `https://ajitpratap0.github.io/GoSQLX/playground/` - WASM-powered SQL playground

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=for-the-badge)](http://makeapullrequest.com)
 [![GitHub Marketplace](https://img.shields.io/badge/Marketplace-GoSQLX%20Lint-blue?style=for-the-badge&logo=github)](https://github.com/marketplace/actions/gosqlx-lint-action)
 [![VS Code Marketplace](https://img.shields.io/visual-studio-marketplace/v/ajitpratap0.gosqlx?style=for-the-badge&logo=visual-studio-code&label=VS%20Code)](https://marketplace.visualstudio.com/items?itemName=ajitpratap0.gosqlx)
+[![Website](https://img.shields.io/badge/Website-GoSQLX-blue?style=for-the-badge&logo=google-chrome)](https://ajitpratap0.github.io/GoSQLX/)
 
 [![Tests](https://img.shields.io/github/actions/workflow/status/ajitpratap0/GoSQLX/test.yml?branch=main&label=Tests&style=flat-square)](https://github.com/ajitpratap0/GoSQLX/actions)
 [![Go Report Card](https://goreportcard.com/badge/github.com/ajitpratap0/GoSQLX?style=flat-square)](https://goreportcard.com/report/github.com/ajitpratap0/GoSQLX)
@@ -25,6 +26,8 @@
 *Zero-copy tokenization • Object pooling • Multi-dialect engine • Query transforms • WASM playground • [Python bindings](python/README.md)*
 
 ### 🚀 **New to GoSQLX? [Get Started in 5 Minutes →](docs/GETTING_STARTED.md)**
+
+### 🌐 **[Try the Interactive Playground →](https://ajitpratap0.github.io/GoSQLX/playground/)**
 
 [📖 Installation](#-installation) • [⚡ Quick Start](#-quick-start) • [📚 Documentation](#-documentation) • [💡 Examples](#-examples) • [📊 Benchmarks](#-performance)
 

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -1106,7 +1106,7 @@ Add documentation link.
 ```go
 err := errors.NewSyntaxError("Missing WHERE clause", &loc).
     WithHint("Consider adding a WHERE clause to filter results").
-    WithDocURL("https://gosqlx.dev/docs/where-clause")
+    WithDocURL("https://ajitpratap0.github.io/GoSQLX/docs/where-clause")
 ```
 
 ---

--- a/llms.txt
+++ b/llms.txt
@@ -8,6 +8,8 @@ PostgreSQL, MySQL, SQL Server, Oracle, SQLite, and Snowflake dialects, and ships
 CLI tool (`gosqlx`) for validation, formatting, linting, and security analysis. Apache-2.0 licensed.
 
 Current stable version: v1.11.0 (2026-03-13)
+Website: https://ajitpratap0.github.io/GoSQLX/
+Interactive Playground: https://ajitpratap0.github.io/GoSQLX/playground/
 
 ## Core API
 

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -12,7 +12,7 @@
   "bugs": {
     "url": "https://github.com/ajitpratap0/GoSQLX/issues"
   },
-  "homepage": "https://github.com/ajitpratap0/GoSQLX#readme",
+  "homepage": "https://ajitpratap0.github.io/GoSQLX/",
   "icon": "images/icon.png",
   "engines": {
     "vscode": "^1.85.0"


### PR DESCRIPTION
## Summary
Add the website URL (https://ajitpratap0.github.io/GoSQLX/) to all relevant project files.

### Changes
- **GitHub repo settings**: Updated homepage from pkg.go.dev to the website
- **README.md**: Added Website badge + "Try the Interactive Playground" link
- **vscode-extension/package.json**: Updated homepage field
- **llms.txt**: Added Website and Interactive Playground URLs
- **CLAUDE.md**: Added website links to Additional Documentation section
- **docs/API_REFERENCE.md**: Fixed incorrect `gosqlx.dev` domain reference

🤖 Generated with [Claude Code](https://claude.com/claude-code)