### PR TITLE
release: v1.12.1 - website performance & mobile optimization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to GoSQLX will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.12.1] - 2026-03-15 - Website Performance & Mobile Optimization
+
+### Improved
+- Lighthouse Desktop: 100 Performance, 100 Accessibility, 100 SEO
+- Lighthouse Mobile: 94 Performance, 100 Accessibility, 100 SEO
+- CLS reduced from 0.382 to 0 (removed stats animation, added image dimensions, font-size-adjust)
+- FCP improved from 2.7s to 2.0s on mobile (self-hosted fonts via @fontsource)
+- LCP improved from 3.0s to 2.4s on mobile
+- Self-hosted fonts eliminate external Google Fonts request
+- AnalyzeTab lazy-loaded via React.lazy() (328KB -> 3.4KB initial chunk)
+- WebP logo (7KB vs 134KB PNG)
+- Non-blocking font loading with preload/swap pattern
+
+### Fixed
+- 20 mobile responsiveness fixes (touch targets, overflow, responsive layout)
+- Design consistency (unified cards, buttons, code blocks, padding across all pages)
+- WCAG contrast (text-slate-500 -> text-slate-400 for readable text)
+- Navbar backdrop-blur for visual separation from hero
+- OFL-1.1 license added to CI allow-list for fontsource packages
+
+### Changed
+- README redesigned from 1,209 to 215 lines with visual feature grid
+- Emdashes replaced with hyphens across 122 files
+
 ## [1.12.0] - 2026-03-15 — Custom Domain & Remote MCP Server
 
 ### Added

--- a/cmd/gosqlx/cmd/doc.go
+++ b/cmd/gosqlx/cmd/doc.go
@@ -341,7 +341,7 @@
 //
 // Version information:
 //
-//	Version = "1.12.0" - Current CLI version
+//	Version = "1.12.1" - Current CLI version
 //
 // # Dependencies
 //

--- a/cmd/gosqlx/cmd/root.go
+++ b/cmd/gosqlx/cmd/root.go
@@ -28,12 +28,12 @@ import (
 // This version tracks feature releases and compatibility.
 // Format: MAJOR.MINOR.PATCH (Semantic Versioning 2.0.0)
 //
-// Version 1.12.0 includes:
+// Version 1.12.1 includes:
 //   - MCP Server: All GoSQLX SQL capabilities as Model Context Protocol tools over streamable HTTP
 //   - 7 MCP tools: validate_sql, format_sql, parse_sql, extract_metadata, security_scan, lint_sql, analyze_sql
 //   - Optional bearer token auth via GOSQLX_MCP_AUTH_TOKEN
 //   - Go minimum bumped to 1.23.0 (required by mark3labs/mcp-go)
-var Version = "1.12.0"
+var Version = "1.12.1"
 
 var (
 	// verbose enables detailed output for debugging and troubleshooting.
@@ -121,7 +121,7 @@ Key features:
 • CI/CD integration with proper exit codes
 
 Performance: 1.5M+ operations/second sustained, 1.97M peak. 100-1000x faster than competitors.`,
-	Version: "1.12.0",
+	Version: "1.12.1",
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.

--- a/cmd/gosqlx/doc.go
+++ b/cmd/gosqlx/doc.go
@@ -24,7 +24,7 @@
 //
 // # Version
 //
-// Current version: 1.12.0
+// Current version: 1.12.1
 //
 // # Architecture
 //

--- a/doc.go
+++ b/doc.go
@@ -16,7 +16,7 @@
 // zero-copy tokenization and comprehensive object pooling. It offers enterprise-grade SQL lexing,
 // parsing, and AST generation with support for multiple SQL dialects and advanced SQL features.
 //
-// GoSQLX v1.12.0 includes both a powerful Go SDK and a high-performance CLI tool for SQL processing,
+// GoSQLX v1.12.1 includes both a powerful Go SDK and a high-performance CLI tool for SQL processing,
 // validated for production deployment with race-free concurrent operation and extensive real-world testing.
 //
 // Production Status: VALIDATED FOR PRODUCTION DEPLOYMENT (v1.6.0+)
@@ -278,6 +278,7 @@
 //
 // # Version History
 //
+// v1.12.1: Website performance - mobile 94, desktop 100, self-hosted fonts, CLS 0
 // v1.12.0: Custom domain gosqlx.dev, remote MCP server at mcp.gosqlx.dev
 // v1.11.1: Website audit fixes, SEO, lazy WASM, design polish
 // v1.11.0: VS Code Marketplace publishing with bundled platform-specific binaries

--- a/llms.txt
+++ b/llms.txt
@@ -7,7 +7,7 @@ recursive-descent parsing, and AST generation with comprehensive object pooling.
 PostgreSQL, MySQL, SQL Server, Oracle, SQLite, and Snowflake dialects, and ships a full-featured
 CLI tool (`gosqlx`) for validation, formatting, linting, and security analysis. Apache-2.0 licensed.
 
-Current stable version: v1.12.0 (2026-03-13)
+Current stable version: v1.12.1 (2026-03-13)
 Website: https://gosqlx.dev
 Interactive Playground: https://gosqlx.dev/playground/
 

--- a/performance_baselines.json
+++ b/performance_baselines.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.12.0",
+  "version": "1.12.1",
   "updated": "2026-03-13",
   "baselines": {
     "SimpleSelect": {

--- a/pkg/gosqlx/gosqlx.go
+++ b/pkg/gosqlx/gosqlx.go
@@ -28,7 +28,7 @@ import (
 )
 
 // Version is the current GoSQLX library version.
-const Version = "1.12.0"
+const Version = "1.12.1"
 
 // Parse tokenizes and parses SQL in one call, returning an Abstract Syntax Tree (AST).
 //

--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -35,7 +35,7 @@ func New(cfg *Config) *Server {
 	s := &Server{cfg: cfg}
 	s.mcpSrv = mcpserver.NewMCPServer(
 		"gosqlx-mcp",
-		"1.12.0",
+		"1.12.1",
 		mcpserver.WithToolCapabilities(false),
 	)
 	s.registerTools()

--- a/vscode-extension/CHANGELOG.md
+++ b/vscode-extension/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the "GoSQLX" extension will be documented in this file.
 
+## [1.12.1] - 2026-03-15
+
+### Changed
+- Version aligned with GoSQLX core (1.12.1)
+
 ## [1.12.0] - 2026-03-15
 
 ### Changed

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gosqlx",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "gosqlx",
   "displayName": "GoSQLX",
   "description": "High-performance SQL parsing, validation, formatting, and analysis powered by GoSQLX",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "publisher": "ajitpratap0",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
## Release v1.12.1

Version bump capturing 4 post-v1.12.0 PRs focused on website performance, mobile optimization, and design polish.

### Lighthouse Scores

| | Desktop | Mobile |
|---|---|---|
| **Performance** | **100** | **94** |
| **Accessibility** | **100** | **100** |
| **Best Practices** | 96 | 92 |
| **SEO** | **100** | **100** |

### Core Web Vitals Improvements

| Metric | Before (v1.12.0) | After (v1.12.1) | Change |
|---|---|---|---|
| CLS (Desktop) | 0.382 | **0** | Fixed |
| CLS (Mobile) | 0.382 | **0** | Fixed |
| FCP (Mobile) | 2.7s | **2.0s** | -26% |
| LCP (Mobile) | 3.0s | **2.4s** | -20% |
| Speed Index (Mobile) | 4.4s | **4.1s** | -7% |

### What's in v1.12.1

**Performance (PRs #383, #384, #385)**
- Self-hosted fonts via `@fontsource` (eliminates external Google Fonts request)
- CLS fixed: removed stats animation, added image dimensions, font-size-adjust
- AnalyzeTab lazy-loaded via `React.lazy()` (328KB -> 3.4KB initial)
- WebP logo (7KB vs 134KB PNG)
- Non-blocking font loading

**Mobile Responsiveness (PR #383)**
- 20 fixes: touch targets (44px+), CodeMirror overflow, responsive layouts
- Hamburger menu, footer links, tab buttons all meet WCAG touch guidelines

**Design Consistency (PR #383)**
- Unified cards, buttons, code blocks, section padding across all pages
- WCAG contrast fixes (text-slate-500 -> text-slate-400)
- Navbar backdrop-blur for frosted glass effect

**README (PR #382)**
- Redesigned from 1,209 to 215 lines
- Visual feature grid, side-by-side install table, contributing CTA
- Emdashes replaced with hyphens across 122 files

**CI (PR #385)**
- OFL-1.1 license added to allowed list for fontsource packages

### Files changed
- 12 version files bumped (Go source, MCP, CLI, VS Code extension, llms.txt, baselines)
- CHANGELOG.md updated with comprehensive v1.12.1 notes
- vscode-extension/CHANGELOG.md updated

### Post-merge steps
1. Tag: `git tag v1.12.1 -a -m "v1.12.1: Website performance - mobile 94, desktop 100"`
2. Push tag: `git push origin v1.12.1`
3. This triggers VS Code extension publish + GitHub release automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)