### PR TITLE
chore: update license allowlist for Next.js deps

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -168,7 +168,7 @@ jobs:
           # to handle golang.org/x packages which report as compound license
           allow-licenses: >-
             MIT, Apache-2.0, BSD-2-Clause, BSD-3-Clause, ISC,
-            BlueOak-1.0.0, OFL-1.1,
+            BlueOak-1.0.0, OFL-1.1, CC-BY-4.0, MPL-2.0,
             LicenseRef-scancode-google-patent-license-golang,
             BSD-3-Clause AND LicenseRef-scancode-google-patent-license-golang
 


### PR DESCRIPTION
## Summary

Add `CC-BY-4.0` and `MPL-2.0` licenses to the CI dependency review allowlist.

### Why
Next.js depends on `caniuse-lite` (CC-BY-4.0) and other packages that use MPL-2.0. These are standard open-source licenses but were not in the project's security workflow allowlist, causing the Dependency Review CI check to fail.

### Changes
- `.github/workflows/security.yml` - Added `CC-BY-4.0` and `MPL-2.0` to the `allow-licenses` list

### Context
This is a prerequisite for the Next.js website rebuild (PR #390). These licenses are well-established open-source licenses compatible with Apache-2.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)