### PR TITLE
fix(website): enable Next.js static export for GitHub Pages

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: website/dist
+          path: website/out
 
   deploy:
     needs: build

--- a/website/next.config.ts
+++ b/website/next.config.ts
@@ -6,6 +6,10 @@ const withAnalyzer = withBundleAnalyzer({
 });
 
 const nextConfig: NextConfig = {
+  output: 'export',
+  images: {
+    unoptimized: true,
+  },
   async headers() {
     return [
       {

--- a/website/public/CNAME
+++ b/website/public/CNAME
@@ -1,0 +1,1 @@
+gosqlx.dev


### PR DESCRIPTION
## Summary
- Add `output: 'export'` and `images: { unoptimized: true }` to `next.config.ts` so `next build` generates static HTML into `website/out/`
- Update `website.yml` artifact path from `website/dist` (Astro) → `website/out` (Next.js)
- Restore `website/public/CNAME` with `gosqlx.dev` to preserve the custom domain on each deploy

## Why
The deploy workflow was failing with `tar: website/dist: Cannot open: No such file or directory` after migrating from Astro to Next.js in #390.

🤖 Generated with [Claude Code](https://claude.com/claude-code)