### PR TITLE
fix(ci): remove WASM auto-commit step — blocked by branch protection

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
   group: vercel-production
@@ -38,18 +38,6 @@ jobs:
           mkdir -p ../website/public/wasm
           cp playground/gosqlx.wasm ../website/public/wasm/
           cp playground/wasm_exec.js ../website/public/wasm/
-
-      - name: Commit rebuilt WASM if changed
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add website/public/wasm/gosqlx.wasm website/public/wasm/wasm_exec.js
-          if git diff --cached --quiet; then
-            echo "WASM unchanged, skipping commit"
-          else
-            git commit -m "chore(wasm): rebuild gosqlx.wasm from updated wasm/ source [skip ci]"
-            git push origin main
-          fi
 
       - name: Setup Node
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Problem

PR #423 introduced an auto-commit step in `website.yml` that rebuilds and pushes `gosqlx.wasm` back to `main` when the source changes. This step fails immediately with:

```
remote: error: GH013: Repository rule violations found for refs/heads/main.
error: failed to push some refs to 'https://github.com/ajitpratap0/GoSQLX'
```

Branch protection requires all changes to `main` go through PRs — even from CI bots. The push is blocked, which aborts the entire deploy pipeline **before Vercel runs**, meaning the playground is still broken.

## Fix

- Remove the auto-commit step entirely
- Revert `permissions: contents` back to `read`
- The WASM binary is now committed to git (from PR #423), so both Vercel auto-deploy and CI deploy will include it without any special step

## When wasm/ source changes in future

Rebuild manually: `cd wasm && make build && cp playground/gosqlx.wasm ../website/public/wasm/ && git add website/public/wasm/gosqlx.wasm && git commit -m "chore(wasm): rebuild"` — then open a PR as normal.

## Test plan
- [ ] `website.yml` deploy completes successfully
- [ ] `https://gosqlx.dev/wasm/gosqlx.wasm` returns HTTP 200
- [ ] Playground parses SQL without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)