### PR TITLE
fix(playground): fix React error #310 — hooks after early returns

### DIFF
--- a/website/src/components/playground/Playground.tsx
+++ b/website/src/components/playground/Playground.tsx
@@ -109,6 +109,15 @@ export default function Playground() {
     []
   );
 
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = useCallback(() => {
+    navigator.clipboard.writeText('go get github.com/ajitpratap0/GoSQLX').then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  }, []);
+
   if (loading) {
     return (
       <div className="flex flex-col h-full bg-[#09090b]" aria-busy="true" aria-label="Loading SQL parser">
@@ -190,15 +199,7 @@ export default function Playground() {
     );
   }
 
-  const [copied, setCopied] = useState(false);
   const hasResults = results.ast !== null;
-
-  const handleCopy = useCallback(() => {
-    navigator.clipboard.writeText('go get github.com/ajitpratap0/GoSQLX').then(() => {
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
-    });
-  }, []);
 
   return (
     <div className="flex flex-col h-full bg-[#09090b]">


### PR DESCRIPTION
## Production Blocker Fix

**Symptom:** gosqlx.dev/playground shows "Failed to load SQL parser" with Minified React error #310

**Root Cause:** `useState(copied)` and `useCallback(handleCopy)` were declared on lines 193–201, **after** two conditional early returns (`if (loading)` at line 112, `if (error)` at line 176). This violates the React Rules of Hooks.

**Why it broke today:** Before commit #423 (commit gosqlx.wasm to fix 404), the WASM binary returned HTTP 404. The component always ended up in the `error` branch, so both renders exited with the same hook count (9 hooks) — the violation was hidden. After #423, the WASM loads successfully and the component transitions `loading=true → ready=true`. React sees 9 hooks on render 1 and 11 hooks on render 2 → error #310 ("Rendered more hooks than during the previous render").

**Fix:** Move `useState(false)` and `useCallback(handleCopy)` above all conditional returns (line 112). No other logic changed.

## Test plan
- [ ] Visit https://gosqlx.dev/playground after deploy — should load and parse SQL
- [ ] No React error in console
- [ ] Copy button works (tests the moved hooks)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)