### PR TITLE
feat(ci): Sentry → GitHub Issues automation

### DIFF
--- a/.github/scripts/sentry_issues.py
+++ b/.github/scripts/sentry_issues.py
@@ -10,6 +10,7 @@ import os
 import sys
 import time
 from datetime import datetime, timezone, timedelta
+from typing import Any
 
 import requests
 
@@ -33,14 +34,18 @@ GITHUB_HEADERS = {
     "X-GitHub-Api-Version": "2022-11-28",
 }
 
-# Sentry level -> GitHub severity label
-LEVEL_TO_SEVERITY = {
-    "fatal":   "severity: critical",
-    "error":   "severity: high",
-    "warning": "severity: medium",
-    "info":    "severity: low",
-    "debug":   "severity: low",
+# Sentry level -> (severity label, include "bug" label)
+# fatal/error are genuine bugs; warning/info/debug are not necessarily bugs.
+LEVEL_TO_SEVERITY: dict[str, tuple[str, bool]] = {
+    "fatal":   ("severity: critical", True),
+    "error":   ("severity: high",     True),
+    "warning": ("severity: medium",   False),
+    "info":    ("severity: low",      False),
+    "debug":   ("severity: low",      False),
 }
+
+# Transient HTTP status codes that are safe to retry
+RETRYABLE_STATUSES = {429, 500, 502, 503, 504}
 
 LABELS_TO_BOOTSTRAP = [
     {"name": "sentry",             "color": "6f42c1", "description": "Automatically created from Sentry error monitoring"},
@@ -55,14 +60,33 @@ LABELS_TO_BOOTSTRAP = [
 # Helpers
 # ---------------------------------------------------------------------------
 
+def request_with_retry(
+    method: str,
+    url: str,
+    *,
+    max_attempts: int = 3,
+    **kwargs: Any,
+) -> requests.Response:
+    """Perform an HTTP request, retrying on transient errors with exponential backoff."""
+    kwargs.setdefault("timeout", 30)
+    for attempt in range(1, max_attempts + 1):
+        resp = requests.request(method, url, **kwargs)
+        if resp.status_code not in RETRYABLE_STATUSES:
+            return resp
+        wait = 2 ** attempt  # 2s, 4s, 8s
+        print(f"  Transient {resp.status_code} on attempt {attempt}/{max_attempts}, retrying in {wait}s...")
+        if attempt < max_attempts:
+            time.sleep(wait)
+    return resp  # Return last response after exhausting retries
+
+
 def ensure_label(name: str, color: str, description: str) -> None:
     """Create a GitHub label if it does not already exist."""
     url = f"{GITHUB_API}/repos/{GITHUB_REPO}/labels"
-    resp = requests.post(
-        url,
+    resp = request_with_retry(
+        "POST", url,
         headers=GITHUB_HEADERS,
         json={"name": name, "color": color, "description": description},
-        timeout=30,
     )
     if resp.status_code == 201:
         print(f"  Created label: {name}")
@@ -82,19 +106,42 @@ def bootstrap_labels() -> None:
 
 
 def fetch_sentry_issues(cutoff: datetime) -> list[dict]:
-    """Return all unresolved Sentry issues first seen after cutoff."""
-    url = f"{SENTRY_API}/projects/{SENTRY_ORG}/{SENTRY_PROJECT}/issues/"
-    params = {"query": "is:unresolved", "limit": 100, "sort": "date"}
-    resp = requests.get(url, headers=SENTRY_HEADERS, params=params, timeout=30)
-    if resp.status_code != 200:
-        print(f"ERROR: Sentry API returned {resp.status_code}: {resp.text}", file=sys.stderr)
-        sys.exit(1)
+    """Return all unresolved Sentry issues first seen after cutoff.
 
-    # Python 3.11+ fromisoformat handles Z natively; we target 3.12 in the workflow
-    return [
-        issue for issue in resp.json()
-        if datetime.fromisoformat(issue["firstSeen"]) >= cutoff
-    ]
+    Follows Sentry's Link-header pagination so no issues are missed even when
+    there are more than 100 unresolved issues in the project.
+
+    Python 3.11+ fromisoformat handles the trailing 'Z' natively (no replace needed).
+    """
+    url: str | None = f"{SENTRY_API}/projects/{SENTRY_ORG}/{SENTRY_PROJECT}/issues/"
+    params: dict | None = {"query": "is:unresolved", "limit": 100, "sort": "date"}
+    new_issues: list[dict] = []
+
+    while url:
+        resp = request_with_retry("GET", url, headers=SENTRY_HEADERS, params=params)
+        if resp.status_code != 200:
+            print(f"ERROR: Sentry API returned {resp.status_code}: {resp.text}", file=sys.stderr)
+            sys.exit(1)
+
+        page = resp.json()
+        for issue in page:
+            first_seen = datetime.fromisoformat(issue["firstSeen"])
+            if first_seen >= cutoff:
+                new_issues.append(issue)
+            else:
+                # Issues are sorted by date desc; once we pass the cutoff, stop paginating.
+                return new_issues
+
+        # Follow next-page link if present (format: <url>; rel="next"; results="true")
+        link_header = resp.headers.get("Link", "")
+        url = None
+        params = None
+        for part in link_header.split(","):
+            if 'rel="next"' in part and 'results="true"' in part:
+                url = part.split(";")[0].strip().strip("<>")
+                break
+
+    return new_issues
 
 
 def github_issue_exists(sentry_id: str) -> bool:
@@ -104,7 +151,7 @@ def github_issue_exists(sentry_id: str) -> bool:
     """
     url = f"{GITHUB_API}/search/issues"
     query = f'repo:{GITHUB_REPO} label:sentry in:body "SENTRY_ID:{sentry_id}"'
-    resp = requests.get(url, headers=GITHUB_HEADERS, params={"q": query, "per_page": 1}, timeout=30)
+    resp = request_with_retry("GET", url, headers=GITHUB_HEADERS, params={"q": query, "per_page": 1})
     if resp.status_code != 200:
         print(f"ERROR: GitHub search failed ({resp.status_code}): {resp.text}", file=sys.stderr)
         sys.exit(1)
@@ -150,18 +197,18 @@ def build_issue_body(issue: dict) -> str:
 
 def create_github_issue(issue: dict) -> None:
     level = issue.get("level", "error")
-    severity_label = LEVEL_TO_SEVERITY.get(level, "severity: high")
-    labels = ["sentry", "bug", severity_label]
+    severity_label, is_bug = LEVEL_TO_SEVERITY.get(level, ("severity: high", True))
+    # Only add "bug" for fatal/error levels — warnings and below are not necessarily bugs
+    labels = ["sentry", severity_label] + (["bug"] if is_bug else [])
 
     title = f"[Sentry] {issue['title']}"
     body = build_issue_body(issue)
 
     url = f"{GITHUB_API}/repos/{GITHUB_REPO}/issues"
-    resp = requests.post(
-        url,
+    resp = request_with_retry(
+        "POST", url,
         headers=GITHUB_HEADERS,
         json={"title": title, "body": body, "labels": labels},
-        timeout=30,
     )
     if resp.status_code == 201:
         data = resp.json()

--- a/.github/workflows/sentry-to-github.yml
+++ b/.github/workflows/sentry-to-github.yml
@@ -32,5 +32,7 @@ jobs:
           SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPO: ${{ github.repository }}
+          # 31 min (not 30) to overlap slightly with the previous run window,
+          # absorbing GitHub Actions scheduling jitter (~1-2 min on busy runners).
           POLLING_MINUTES: '31'
         run: python .github/scripts/sentry_issues.py


### PR DESCRIPTION
## Summary

- Adds a GitHub Actions workflow that polls Sentry every 30 minutes for new unresolved issues
- Automatically creates GitHub issues with full error context, severity labels, and deduplication
- Backfilled 4 existing Sentry issues as GitHub issues #434–#437

## What's included

**`.github/workflows/sentry-to-github.yml`**
- Runs on a `*/30 * * * *` cron schedule + `workflow_dispatch` for manual testing
- Minimal permissions: `issues: write`, `contents: read`
- Passes secrets via `env:` (no inline interpolation into `run:`)

**`.github/scripts/sentry_issues.py`**
- Polls `GET /api/0/projects/{org}/{project}/issues/?query=is:unresolved`
- Filters by `firstSeen >= now - 31min` (31min to handle scheduling jitter)
- Deduplicates via `<!-- SENTRY_ID:{id} -->` hidden marker in issue body
- Creates labels (`sentry`, `severity: critical/high/medium/low`) on first run
- Rate-limit guard: 2s sleep between GitHub search API calls

## Sentry → severity label mapping

| Sentry level | Label |
|---|---|
| fatal | `severity: critical` |
| error | `severity: high` |
| warning | `severity: medium` |
| info / debug | `severity: low` |

## Required secrets (already set)

- `SENTRY_AUTH_TOKEN` — set via `gh secret set`
- `SENTRY_ORG` — set to `ajit-pratap-singh`
- `GITHUB_TOKEN` — automatic

## Current Sentry issues backfilled

| GitHub | Sentry ID | Title |
|---|---|---|
| #434 | 106232192 | TypeError: pushState read-only (docs route) |
| #435 | 105431404 | UnhandledRejection: Object Not Found (playground) |
| #436 | 104333516 | Hydration mismatch on homepage (Framer Motion) |
| #437 | 104333514 | Hydration Error replay (same root cause as #436) |

## Test plan

- [ ] Trigger `workflow_dispatch` from Actions tab — verify no duplicate issues created
- [ ] Verify labels exist in repo: `sentry`, `severity: *`
- [ ] Force a test Sentry event and confirm a new GitHub issue is created within 30 min

🤖 Generated with [Claude Code](https://claude.com/claude-code)