### PR TITLE
feat(advisor): expand query advisor from 8 to 20 rules (OPT-009 through OPT-020)

### DIFF
--- a/pkg/advisor/advisor_advanced_test.go
+++ b/pkg/advisor/advisor_advanced_test.go
@@ -1,0 +1,664 @@
+// Copyright 2026 GoSQLX Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package advisor
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/ajitpratap0/GoSQLX/pkg/gosqlx"
+	"github.com/ajitpratap0/GoSQLX/pkg/sql/ast"
+)
+
+// analyzeWithRule parses sql and runs a single Rule against the first statement.
+func analyzeWithRule(t *testing.T, sql string, rule Rule) []Suggestion {
+	t.Helper()
+	tree, err := gosqlx.Parse(sql)
+	if err != nil {
+		t.Fatalf("Parse(%q): %v", sql, err)
+	}
+	if len(tree.Statements) == 0 {
+		t.Fatal("no statements parsed")
+	}
+	return rule.Analyze(tree.Statements[0])
+}
+
+// ---------------------------------------------------------------------------
+// OPT-009: Correlated Subquery in SELECT List
+// ---------------------------------------------------------------------------
+
+func TestOPT009_CorrelatedSubqueryInSelect_Violation(t *testing.T) {
+	rule := &CorrelatedSubqueryInSelectRule{}
+	sug := analyzeWithRule(t,
+		`SELECT id, (SELECT name FROM departments WHERE id = e.dept_id) AS dept_name FROM employees e`,
+		rule)
+	if len(sug) == 0 {
+		t.Error("expected N+1 warning for correlated subquery in SELECT list")
+	}
+	if sug[0].RuleID != "OPT-009" {
+		t.Errorf("expected RuleID OPT-009, got %q", sug[0].RuleID)
+	}
+}
+
+func TestOPT009_CorrelatedSubqueryInSelect_NoViolation(t *testing.T) {
+	rule := &CorrelatedSubqueryInSelectRule{}
+	sug := analyzeWithRule(t,
+		`SELECT e.id, d.name FROM employees e JOIN departments d ON e.dept_id = d.id`,
+		rule)
+	if len(sug) != 0 {
+		t.Errorf("expected no violation for JOIN query, got %d suggestion(s)", len(sug))
+	}
+}
+
+func TestOPT009_ColumnsOnly_NoViolation(t *testing.T) {
+	rule := &CorrelatedSubqueryInSelectRule{}
+	sug := analyzeWithRule(t, `SELECT id, name, status FROM users WHERE active = true`, rule)
+	if len(sug) != 0 {
+		t.Errorf("expected no violation for plain column list, got %d", len(sug))
+	}
+}
+
+func TestOPT009_RuleMetadata(t *testing.T) {
+	rule := &CorrelatedSubqueryInSelectRule{}
+	if rule.ID() != "OPT-009" {
+		t.Errorf("ID() = %q, want OPT-009", rule.ID())
+	}
+	if rule.Name() == "" {
+		t.Error("Name() must not be empty")
+	}
+	if rule.Description() == "" {
+		t.Error("Description() must not be empty")
+	}
+}
+
+func TestOPT009_NonSelect_NoViolation(t *testing.T) {
+	rule := &CorrelatedSubqueryInSelectRule{}
+	tree, err := gosqlx.Parse("UPDATE users SET name = 'test' WHERE id = 1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	sug := rule.Analyze(tree.Statements[0])
+	if len(sug) != 0 {
+		t.Errorf("expected no violation for UPDATE, got %d", len(sug))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// OPT-010: HAVING Without GROUP BY
+// ---------------------------------------------------------------------------
+
+func TestOPT010_HavingWithoutGroupBy_Violation(t *testing.T) {
+	rule := &HavingWithoutGroupByRule{}
+	sug := analyzeWithRule(t, "SELECT COUNT(*) FROM users HAVING COUNT(*) > 0", rule)
+	if len(sug) == 0 {
+		t.Error("expected violation for HAVING without GROUP BY")
+	}
+	if sug[0].RuleID != "OPT-010" {
+		t.Errorf("expected RuleID OPT-010, got %q", sug[0].RuleID)
+	}
+}
+
+func TestOPT010_HavingWithGroupBy_NoViolation(t *testing.T) {
+	rule := &HavingWithoutGroupByRule{}
+	sug := analyzeWithRule(t, "SELECT dept, COUNT(*) FROM users GROUP BY dept HAVING COUNT(*) > 5", rule)
+	if len(sug) != 0 {
+		t.Errorf("expected no violation for HAVING with GROUP BY, got %d", len(sug))
+	}
+}
+
+func TestOPT010_NoHaving_NoViolation(t *testing.T) {
+	rule := &HavingWithoutGroupByRule{}
+	sug := analyzeWithRule(t, "SELECT id, name FROM users WHERE active = true", rule)
+	if len(sug) != 0 {
+		t.Errorf("expected no violation for query without HAVING, got %d", len(sug))
+	}
+}
+
+func TestOPT010_RuleMetadata(t *testing.T) {
+	rule := &HavingWithoutGroupByRule{}
+	if rule.ID() != "OPT-010" {
+		t.Errorf("ID() = %q, want OPT-010", rule.ID())
+	}
+	if rule.Name() == "" || rule.Description() == "" {
+		t.Error("Name() and Description() must not be empty")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// OPT-011: Redundant ORDER BY in CTE
+// ---------------------------------------------------------------------------
+
+func TestOPT011_OrderByInCTE_Violation(t *testing.T) {
+	rule := &RedundantOrderByInCTERule{}
+	sug := analyzeWithRule(t, `
+		WITH ranked AS (
+			SELECT id, name FROM users ORDER BY name
+		)
+		SELECT * FROM ranked`, rule)
+	if len(sug) == 0 {
+		t.Error("expected warning for ORDER BY inside CTE definition")
+	}
+	if sug[0].RuleID != "OPT-011" {
+		t.Errorf("expected RuleID OPT-011, got %q", sug[0].RuleID)
+	}
+}
+
+func TestOPT011_OrderByInCTE_WithLimit_NoViolation(t *testing.T) {
+	rule := &RedundantOrderByInCTERule{}
+	sug := analyzeWithRule(t, `
+		WITH top5 AS (
+			SELECT id, name FROM users ORDER BY name LIMIT 5
+		)
+		SELECT * FROM top5`, rule)
+	if len(sug) != 0 {
+		t.Errorf("expected no violation for ORDER BY + LIMIT in CTE, got %d", len(sug))
+	}
+}
+
+func TestOPT011_NoCTE_NoViolation(t *testing.T) {
+	rule := &RedundantOrderByInCTERule{}
+	sug := analyzeWithRule(t, "SELECT id, name FROM users ORDER BY name", rule)
+	if len(sug) != 0 {
+		t.Errorf("expected no violation for outer ORDER BY (not in CTE), got %d", len(sug))
+	}
+}
+
+func TestOPT011_RuleMetadata(t *testing.T) {
+	rule := &RedundantOrderByInCTERule{}
+	if rule.ID() != "OPT-011" {
+		t.Errorf("ID() = %q, want OPT-011", rule.ID())
+	}
+	if rule.Name() == "" || rule.Description() == "" {
+		t.Error("Name() and Description() must not be empty")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// OPT-012: Implicit Type Conversion (CAST in WHERE)
+// ---------------------------------------------------------------------------
+
+func TestOPT012_CastInWhere_Violation(t *testing.T) {
+	rule := &ImplicitTypeConversionRule{}
+	sug := analyzeWithRule(t, "SELECT * FROM orders WHERE CAST(user_id AS VARCHAR) = '123'", rule)
+	if len(sug) == 0 {
+		t.Error("expected warning for CAST in WHERE condition")
+	}
+	if sug[0].RuleID != "OPT-012" {
+		t.Errorf("expected RuleID OPT-012, got %q", sug[0].RuleID)
+	}
+}
+
+func TestOPT012_NoCastInWhere_NoViolation(t *testing.T) {
+	rule := &ImplicitTypeConversionRule{}
+	sug := analyzeWithRule(t, "SELECT * FROM orders WHERE user_id = 123", rule)
+	if len(sug) != 0 {
+		t.Errorf("expected no violation for plain WHERE comparison, got %d", len(sug))
+	}
+}
+
+func TestOPT012_NoWhere_NoViolation(t *testing.T) {
+	rule := &ImplicitTypeConversionRule{}
+	sug := analyzeWithRule(t, "SELECT * FROM orders", rule)
+	if len(sug) != 0 {
+		t.Errorf("expected no violation for query without WHERE, got %d", len(sug))
+	}
+}
+
+func TestOPT012_RuleMetadata(t *testing.T) {
+	rule := &ImplicitTypeConversionRule{}
+	if rule.ID() != "OPT-012" {
+		t.Errorf("ID() = %q, want OPT-012", rule.ID())
+	}
+	if rule.Name() == "" || rule.Description() == "" {
+		t.Error("Name() and Description() must not be empty")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// OPT-013: OR-to-IN Conversion
+// ---------------------------------------------------------------------------
+
+func TestOPT013_OrThreeSameColumn_Violation(t *testing.T) {
+	rule := &OrToInConversionRule{}
+	sug := analyzeWithRule(t, "SELECT * FROM users WHERE status = 1 OR status = 2 OR status = 3", rule)
+	if len(sug) == 0 {
+		t.Error("expected suggestion to replace 3x OR with IN")
+	}
+	if sug[0].RuleID != "OPT-013" {
+		t.Errorf("expected RuleID OPT-013, got %q", sug[0].RuleID)
+	}
+}
+
+func TestOPT013_OrDifferentColumns_NoViolation(t *testing.T) {
+	rule := &OrToInConversionRule{}
+	sug := analyzeWithRule(t, "SELECT * FROM users WHERE status = 1 OR active = true", rule)
+	if len(sug) != 0 {
+		t.Errorf("OR on different columns should not trigger IN suggestion, got %d", len(sug))
+	}
+}
+
+func TestOPT013_OnlyTwoSameColumn_NoViolation(t *testing.T) {
+	rule := &OrToInConversionRule{}
+	sug := analyzeWithRule(t, "SELECT * FROM users WHERE status = 1 OR status = 2", rule)
+	if len(sug) != 0 {
+		t.Errorf("only 2 OR conditions should not trigger (threshold is 3), got %d", len(sug))
+	}
+}
+
+func TestOPT013_NoWhere_NoViolation(t *testing.T) {
+	rule := &OrToInConversionRule{}
+	sug := analyzeWithRule(t, "SELECT * FROM users", rule)
+	if len(sug) != 0 {
+		t.Errorf("expected no violation for query without WHERE, got %d", len(sug))
+	}
+}
+
+func TestOPT013_RuleMetadata(t *testing.T) {
+	rule := &OrToInConversionRule{}
+	if rule.ID() != "OPT-013" {
+		t.Errorf("ID() = %q, want OPT-013", rule.ID())
+	}
+	if rule.Name() == "" || rule.Description() == "" {
+		t.Error("Name() and Description() must not be empty")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// OPT-014: NOT IN Subquery NULL Risk
+// ---------------------------------------------------------------------------
+
+func TestOPT014_NotInSubquery_Violation(t *testing.T) {
+	rule := &NotInSubqueryNullRule{}
+	sug := analyzeWithRule(t,
+		`SELECT * FROM users WHERE id NOT IN (SELECT manager_id FROM employees)`,
+		rule)
+	if len(sug) == 0 {
+		t.Error("expected warning for NOT IN with subquery (NULL risk)")
+	}
+	if sug[0].RuleID != "OPT-014" {
+		t.Errorf("expected RuleID OPT-014, got %q", sug[0].RuleID)
+	}
+}
+
+func TestOPT014_InSubquery_NoViolation(t *testing.T) {
+	rule := &NotInSubqueryNullRule{}
+	sug := analyzeWithRule(t,
+		`SELECT * FROM users WHERE id IN (SELECT manager_id FROM employees)`,
+		rule)
+	if len(sug) != 0 {
+		t.Errorf("IN (not NOT IN) should not trigger, got %d", len(sug))
+	}
+}
+
+func TestOPT014_NotInValueList_NoViolation(t *testing.T) {
+	rule := &NotInSubqueryNullRule{}
+	sug := analyzeWithRule(t,
+		`SELECT * FROM users WHERE status NOT IN (1, 2, 3)`,
+		rule)
+	if len(sug) != 0 {
+		t.Errorf("NOT IN value list (no subquery) should not trigger, got %d", len(sug))
+	}
+}
+
+func TestOPT014_RuleMetadata(t *testing.T) {
+	rule := &NotInSubqueryNullRule{}
+	if rule.ID() != "OPT-014" {
+		t.Errorf("ID() = %q, want OPT-014", rule.ID())
+	}
+	if rule.Name() == "" || rule.Description() == "" {
+		t.Error("Name() and Description() must not be empty")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// OPT-015: Missing LIMIT
+// ---------------------------------------------------------------------------
+
+func TestOPT015_OrderByNoLimit_Violation(t *testing.T) {
+	rule := &MissingLimitRule{}
+	sug := analyzeWithRule(t, "SELECT * FROM audit_log ORDER BY created_at DESC", rule)
+	if len(sug) == 0 {
+		t.Error("expected suggestion to add LIMIT to ORDER BY query without LIMIT")
+	}
+	if sug[0].RuleID != "OPT-015" {
+		t.Errorf("expected RuleID OPT-015, got %q", sug[0].RuleID)
+	}
+}
+
+func TestOPT015_OrderByWithLimit_NoViolation(t *testing.T) {
+	rule := &MissingLimitRule{}
+	sug := analyzeWithRule(t, "SELECT * FROM audit_log ORDER BY created_at DESC LIMIT 100", rule)
+	if len(sug) != 0 {
+		t.Errorf("expected no violation with LIMIT, got %d", len(sug))
+	}
+}
+
+func TestOPT015_NoOrderBy_NoViolation(t *testing.T) {
+	rule := &MissingLimitRule{}
+	sug := analyzeWithRule(t, "SELECT * FROM users WHERE active = true", rule)
+	if len(sug) != 0 {
+		t.Errorf("expected no violation for query without ORDER BY, got %d", len(sug))
+	}
+}
+
+func TestOPT015_RuleMetadata(t *testing.T) {
+	rule := &MissingLimitRule{}
+	if rule.ID() != "OPT-015" {
+		t.Errorf("ID() = %q, want OPT-015", rule.ID())
+	}
+	if rule.Name() == "" || rule.Description() == "" {
+		t.Error("Name() and Description() must not be empty")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// OPT-016: Unused Alias
+// ---------------------------------------------------------------------------
+
+func TestOPT016_UnusedAlias_Violation(t *testing.T) {
+	rule := &UnusedAliasRule{}
+	sug := analyzeWithRule(t,
+		"SELECT id, name AS full_name FROM users ORDER BY name",
+		rule)
+	if len(sug) == 0 {
+		t.Error("expected violation for alias 'full_name' not used in ORDER BY/HAVING")
+	}
+	if sug[0].RuleID != "OPT-016" {
+		t.Errorf("expected RuleID OPT-016, got %q", sug[0].RuleID)
+	}
+}
+
+func TestOPT016_AliasUsedInOrderBy_NoViolation(t *testing.T) {
+	rule := &UnusedAliasRule{}
+	sug := analyzeWithRule(t,
+		"SELECT id, name AS full_name FROM users ORDER BY full_name",
+		rule)
+	if len(sug) != 0 {
+		t.Errorf("expected no violation when alias used in ORDER BY, got %d", len(sug))
+	}
+}
+
+func TestOPT016_NoAlias_NoViolation(t *testing.T) {
+	rule := &UnusedAliasRule{}
+	sug := analyzeWithRule(t, "SELECT id, name FROM users", rule)
+	if len(sug) != 0 {
+		t.Errorf("expected no violation for query without aliases, got %d", len(sug))
+	}
+}
+
+func TestOPT016_RuleMetadata(t *testing.T) {
+	rule := &UnusedAliasRule{}
+	if rule.ID() != "OPT-016" {
+		t.Errorf("ID() = %q, want OPT-016", rule.ID())
+	}
+	if rule.Name() == "" || rule.Description() == "" {
+		t.Error("Name() and Description() must not be empty")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// OPT-017: UNION Deduplication
+// ---------------------------------------------------------------------------
+
+func TestOPT017_Union_Violation(t *testing.T) {
+	rule := &UnionDeduplicationRule{}
+	tree, err := gosqlx.Parse("SELECT id FROM users UNION SELECT id FROM admins")
+	if err != nil {
+		t.Fatalf("Parse error: %v", err)
+	}
+	if len(tree.Statements) == 0 {
+		t.Fatal("no statements parsed")
+	}
+	sug := rule.Analyze(tree.Statements[0])
+	if len(sug) == 0 {
+		t.Error("expected suggestion for UNION (non-ALL) on possibly large result sets")
+	}
+	if sug[0].RuleID != "OPT-017" {
+		t.Errorf("expected RuleID OPT-017, got %q", sug[0].RuleID)
+	}
+}
+
+func TestOPT017_UnionAll_NoViolation(t *testing.T) {
+	rule := &UnionDeduplicationRule{}
+	tree, err := gosqlx.Parse("SELECT id FROM users UNION ALL SELECT id FROM admins")
+	if err != nil {
+		t.Fatalf("Parse error: %v", err)
+	}
+	sug := rule.Analyze(tree.Statements[0])
+	if len(sug) != 0 {
+		t.Errorf("UNION ALL should not trigger, got %d", len(sug))
+	}
+}
+
+func TestOPT017_SelectOnly_NoViolation(t *testing.T) {
+	rule := &UnionDeduplicationRule{}
+	sug := analyzeWithRule(t, "SELECT id FROM users", rule)
+	if len(sug) != 0 {
+		t.Errorf("plain SELECT should not trigger OPT-017, got %d", len(sug))
+	}
+}
+
+func TestOPT017_RuleMetadata(t *testing.T) {
+	rule := &UnionDeduplicationRule{}
+	if rule.ID() != "OPT-017" {
+		t.Errorf("ID() = %q, want OPT-017", rule.ID())
+	}
+	if rule.Name() == "" || rule.Description() == "" {
+		t.Error("Name() and Description() must not be empty")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// OPT-018: COUNT(DISTINCT col) where COUNT(*) may suffice
+// ---------------------------------------------------------------------------
+
+func TestOPT018_CountDistinct_Violation(t *testing.T) {
+	rule := &CountStarRule{}
+	sug := analyzeWithRule(t, "SELECT COUNT(DISTINCT user_id) FROM orders", rule)
+	if len(sug) == 0 {
+		t.Error("expected info suggestion for COUNT(DISTINCT col)")
+	}
+	if sug[0].RuleID != "OPT-018" {
+		t.Errorf("expected RuleID OPT-018, got %q", sug[0].RuleID)
+	}
+}
+
+func TestOPT018_CountStar_NoViolation(t *testing.T) {
+	rule := &CountStarRule{}
+	sug := analyzeWithRule(t, "SELECT COUNT(*) FROM orders", rule)
+	if len(sug) != 0 {
+		t.Errorf("COUNT(*) should not trigger OPT-018, got %d", len(sug))
+	}
+}
+
+func TestOPT018_CountColumn_NoViolation(t *testing.T) {
+	rule := &CountStarRule{}
+	sug := analyzeWithRule(t, "SELECT COUNT(id) FROM orders", rule)
+	if len(sug) != 0 {
+		t.Errorf("COUNT(col) without DISTINCT should not trigger OPT-018, got %d", len(sug))
+	}
+}
+
+func TestOPT018_RuleMetadata(t *testing.T) {
+	rule := &CountStarRule{}
+	if rule.ID() != "OPT-018" {
+		t.Errorf("ID() = %q, want OPT-018", rule.ID())
+	}
+	if rule.Name() == "" || rule.Description() == "" {
+		t.Error("Name() and Description() must not be empty")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// OPT-019: Deep Subquery Nesting
+// ---------------------------------------------------------------------------
+
+func TestOPT019_DeepNesting_Violation(t *testing.T) {
+	rule := &DeepSubqueryNestingRule{}
+	sug := analyzeWithRule(t,
+		`SELECT * FROM a WHERE id IN (SELECT id FROM b WHERE id IN (SELECT id FROM c WHERE id IN (SELECT id FROM d WHERE id IN (SELECT id FROM e))))`,
+		rule)
+	if len(sug) == 0 {
+		t.Error("expected warning for deeply nested subqueries (>3 levels)")
+	}
+	if sug[0].RuleID != "OPT-019" {
+		t.Errorf("expected RuleID OPT-019, got %q", sug[0].RuleID)
+	}
+}
+
+func TestOPT019_ShallowNesting_NoViolation(t *testing.T) {
+	rule := &DeepSubqueryNestingRule{}
+	sug := analyzeWithRule(t,
+		`SELECT * FROM a WHERE id IN (SELECT id FROM b WHERE id IN (SELECT id FROM c))`,
+		rule)
+	if len(sug) != 0 {
+		t.Errorf("2-level nesting should not trigger (threshold >3), got %d", len(sug))
+	}
+}
+
+func TestOPT019_NoSubquery_NoViolation(t *testing.T) {
+	rule := &DeepSubqueryNestingRule{}
+	sug := analyzeWithRule(t, "SELECT * FROM users WHERE active = true", rule)
+	if len(sug) != 0 {
+		t.Errorf("no subquery should not trigger OPT-019, got %d", len(sug))
+	}
+}
+
+func TestOPT019_RuleMetadata(t *testing.T) {
+	rule := &DeepSubqueryNestingRule{}
+	if rule.ID() != "OPT-019" {
+		t.Errorf("ID() = %q, want OPT-019", rule.ID())
+	}
+	if rule.Name() == "" || rule.Description() == "" {
+		t.Error("Name() and Description() must not be empty")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// OPT-020: Explicit Cross Join / Cartesian Product
+// ---------------------------------------------------------------------------
+
+func TestOPT020_ExplicitCrossJoin_Violation(t *testing.T) {
+	rule := &ExplicitCrossJoinRule{}
+	sug := analyzeWithRule(t, "SELECT * FROM a CROSS JOIN b", rule)
+	if len(sug) == 0 {
+		t.Error("expected warning for explicit CROSS JOIN")
+	}
+	if sug[0].RuleID != "OPT-020" {
+		t.Errorf("expected RuleID OPT-020, got %q", sug[0].RuleID)
+	}
+}
+
+func TestOPT020_InnerJoin_NoViolation(t *testing.T) {
+	rule := &ExplicitCrossJoinRule{}
+	sug := analyzeWithRule(t, "SELECT * FROM a JOIN b ON a.id = b.a_id", rule)
+	if len(sug) != 0 {
+		t.Errorf("INNER JOIN with condition should not trigger OPT-020, got %d", len(sug))
+	}
+}
+
+func TestOPT020_SingleTable_NoViolation(t *testing.T) {
+	rule := &ExplicitCrossJoinRule{}
+	sug := analyzeWithRule(t, "SELECT * FROM users", rule)
+	if len(sug) != 0 {
+		t.Errorf("single table should not trigger OPT-020, got %d", len(sug))
+	}
+}
+
+func TestOPT020_RuleMetadata(t *testing.T) {
+	rule := &ExplicitCrossJoinRule{}
+	if rule.ID() != "OPT-020" {
+		t.Errorf("ID() = %q, want OPT-020", rule.ID())
+	}
+	if rule.Name() == "" || rule.Description() == "" {
+		t.Error("Name() and Description() must not be empty")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Integration: DefaultRules includes all 20 rules
+// ---------------------------------------------------------------------------
+
+func TestDefaultRules_Count(t *testing.T) {
+	rules := DefaultRules()
+	if len(rules) != 20 {
+		t.Errorf("DefaultRules() returned %d rules, want 20", len(rules))
+	}
+}
+
+func TestDefaultRules_UniqueIDs(t *testing.T) {
+	rules := DefaultRules()
+	seen := make(map[string]bool)
+	for _, r := range rules {
+		if seen[r.ID()] {
+			t.Errorf("duplicate rule ID: %s", r.ID())
+		}
+		seen[r.ID()] = true
+	}
+}
+
+func TestDefaultRules_AllNewRulesPresent(t *testing.T) {
+	rules := DefaultRules()
+	ids := make(map[string]bool)
+	for _, r := range rules {
+		ids[r.ID()] = true
+	}
+	for i := 9; i <= 20; i++ {
+		id := fmt.Sprintf("OPT-%03d", i)
+		if !ids[id] {
+			t.Errorf("DefaultRules() missing %s", id)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Integration: Optimizer with advanced rules
+// ---------------------------------------------------------------------------
+
+func TestOptimizer_AdvancedRules_Score(t *testing.T) {
+	opt := New()
+
+	// A correlated subquery + ORDER BY without LIMIT should deduct points
+	result, err := opt.AnalyzeSQL(
+		`SELECT id, (SELECT name FROM depts WHERE id = e.dept_id) FROM employees ORDER BY id`)
+	if err != nil {
+		t.Fatalf("AnalyzeSQL: %v", err)
+	}
+	if result.Score >= 100 {
+		t.Errorf("expected score < 100 for query with multiple issues, got %d", result.Score)
+	}
+}
+
+func TestOptimizer_NotInSubquery_Score(t *testing.T) {
+	opt := New()
+	result, err := opt.AnalyzeSQL(
+		`SELECT * FROM users WHERE id NOT IN (SELECT manager_id FROM employees)`)
+	if err != nil {
+		t.Fatalf("AnalyzeSQL: %v", err)
+	}
+	found := false
+	for _, s := range result.Suggestions {
+		if s.RuleID == "OPT-014" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected OPT-014 suggestion from full optimizer on NOT IN subquery")
+	}
+}
+
+// Ensure the ast package import is used (for type assertions in future tests).
+var _ ast.Statement

--- a/pkg/advisor/optimizer_test.go
+++ b/pkg/advisor/optimizer_test.go
@@ -976,8 +976,8 @@ func TestFormatResult(t *testing.T) {
 
 func TestDefaultRules(t *testing.T) {
 	rules := DefaultRules()
-	if len(rules) != 8 {
-		t.Errorf("expected 8 default rules, got %d", len(rules))
+	if len(rules) != 20 {
+		t.Errorf("expected 20 default rules, got %d", len(rules))
 	}
 
 	ids := make(map[string]bool)
@@ -1006,6 +1006,9 @@ func TestRuleMetadata(t *testing.T) {
 	expectedIDs := []string{
 		"OPT-001", "OPT-002", "OPT-003", "OPT-004",
 		"OPT-005", "OPT-006", "OPT-007", "OPT-008",
+		"OPT-009", "OPT-010", "OPT-011", "OPT-012",
+		"OPT-013", "OPT-014", "OPT-015", "OPT-016",
+		"OPT-017", "OPT-018", "OPT-019", "OPT-020",
 	}
 
 	for i, rule := range rules {

--- a/pkg/advisor/rules.go
+++ b/pkg/advisor/rules.go
@@ -24,6 +24,7 @@ import (
 // DefaultRules returns the default set of all built-in optimization rules.
 func DefaultRules() []Rule {
 	return []Rule{
+		// OPT-001 through OPT-008: original rules
 		&SelectStarRule{},
 		&MissingWhereRule{},
 		&CartesianProductRule{},
@@ -32,6 +33,19 @@ func DefaultRules() []Rule {
 		&OrInWhereRule{},
 		&LeadingWildcardLikeRule{},
 		&FunctionOnColumnRule{},
+		// OPT-009 through OPT-020: advanced rules
+		&CorrelatedSubqueryInSelectRule{},
+		&HavingWithoutGroupByRule{},
+		&RedundantOrderByInCTERule{},
+		&ImplicitTypeConversionRule{},
+		&OrToInConversionRule{},
+		&NotInSubqueryNullRule{},
+		&MissingLimitRule{},
+		&UnusedAliasRule{},
+		&UnionDeduplicationRule{},
+		&CountStarRule{},
+		&DeepSubqueryNestingRule{},
+		&ExplicitCrossJoinRule{},
 	}
 }
 

--- a/pkg/advisor/rules_advanced.go
+++ b/pkg/advisor/rules_advanced.go
@@ -1,0 +1,614 @@
+// Copyright 2026 GoSQLX Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package advisor
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/ajitpratap0/GoSQLX/pkg/sql/ast"
+)
+
+// ---------------------------------------------------------------------------
+// OPT-009: Correlated Subquery in SELECT List (N+1 pattern)
+// ---------------------------------------------------------------------------
+
+// CorrelatedSubqueryInSelectRule detects subqueries in the SELECT column list.
+// Each row in the outer query triggers one inner query — the classic N+1 problem.
+type CorrelatedSubqueryInSelectRule struct{}
+
+func (r *CorrelatedSubqueryInSelectRule) ID() string   { return "OPT-009" }
+func (r *CorrelatedSubqueryInSelectRule) Name() string { return "Correlated Subquery in SELECT" }
+func (r *CorrelatedSubqueryInSelectRule) Description() string {
+	return "Detects correlated subqueries in the SELECT column list which cause N+1 query execution."
+}
+
+func (r *CorrelatedSubqueryInSelectRule) Analyze(stmt ast.Statement) []Suggestion {
+	sel, ok := stmt.(*ast.SelectStatement)
+	if !ok {
+		return nil
+	}
+	var suggestions []Suggestion
+	for _, col := range sel.Columns {
+		// Handle aliased expressions wrapping a subquery
+		inner := col
+		if aliased, ok := col.(*ast.AliasedExpression); ok {
+			inner = aliased.Expr
+		}
+		if _, ok := inner.(*ast.SubqueryExpression); ok {
+			suggestions = append(suggestions, Suggestion{
+				RuleID:       r.ID(),
+				Severity:     SeverityWarning,
+				Message:      "Correlated subquery in SELECT list causes N+1 query execution",
+				Detail:       "Each row in the outer query executes this subquery independently. Replace with a LEFT JOIN for a single-pass query that is typically orders of magnitude faster.",
+				SuggestedSQL: "Replace the subquery with LEFT JOIN ... ON ...",
+			})
+		}
+	}
+	return suggestions
+}
+
+// ---------------------------------------------------------------------------
+// OPT-010: HAVING Without GROUP BY
+// ---------------------------------------------------------------------------
+
+// HavingWithoutGroupByRule detects HAVING clauses without a corresponding GROUP BY.
+// Most databases treat this as a full-table aggregate — rarely the intent.
+type HavingWithoutGroupByRule struct{}
+
+func (r *HavingWithoutGroupByRule) ID() string   { return "OPT-010" }
+func (r *HavingWithoutGroupByRule) Name() string { return "HAVING Without GROUP BY" }
+func (r *HavingWithoutGroupByRule) Description() string {
+	return "HAVING without GROUP BY treats the entire table as one group — usually a logic error."
+}
+
+func (r *HavingWithoutGroupByRule) Analyze(stmt ast.Statement) []Suggestion {
+	sel, ok := stmt.(*ast.SelectStatement)
+	if !ok {
+		return nil
+	}
+	if sel.Having != nil && len(sel.GroupBy) == 0 {
+		return []Suggestion{{
+			RuleID:   r.ID(),
+			Severity: SeverityWarning,
+			Message:  "HAVING clause without GROUP BY groups the entire table as one aggregate",
+			Detail:   "HAVING without GROUP BY is valid SQL but treats all rows as a single group. If you intend to filter individual rows, use WHERE instead.",
+		}}
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// OPT-011: Redundant ORDER BY in CTE
+// ---------------------------------------------------------------------------
+
+// RedundantOrderByInCTERule detects ORDER BY inside a CTE definition without LIMIT.
+// In most databases (PostgreSQL, MySQL, SQL Server, ClickHouse), ORDER BY inside a
+// CTE is ignored unless paired with LIMIT/TOP/FETCH.
+type RedundantOrderByInCTERule struct{}
+
+func (r *RedundantOrderByInCTERule) ID() string   { return "OPT-011" }
+func (r *RedundantOrderByInCTERule) Name() string { return "Redundant ORDER BY in CTE" }
+func (r *RedundantOrderByInCTERule) Description() string {
+	return "ORDER BY inside a CTE definition is ignored by most databases unless combined with LIMIT/TOP."
+}
+
+func (r *RedundantOrderByInCTERule) Analyze(stmt ast.Statement) []Suggestion {
+	sel, ok := stmt.(*ast.SelectStatement)
+	if !ok || sel.With == nil {
+		return nil
+	}
+	var suggestions []Suggestion
+	for _, cte := range sel.With.CTEs {
+		cteQuery, ok := cte.Statement.(*ast.SelectStatement)
+		if !ok {
+			continue
+		}
+		// ORDER BY without LIMIT/FETCH/TOP is redundant in a CTE
+		hasLimit := cteQuery.Limit != nil || cteQuery.Fetch != nil || cteQuery.Top != nil
+		if len(cteQuery.OrderBy) > 0 && !hasLimit {
+			suggestions = append(suggestions, Suggestion{
+				RuleID:   r.ID(),
+				Severity: SeverityInfo,
+				Message:  fmt.Sprintf("ORDER BY in CTE %q is likely ignored by the database", cte.Name),
+				Detail:   "CTE inner ORDER BY is ignored by PostgreSQL, MySQL, SQL Server, and ClickHouse unless combined with LIMIT/TOP/FETCH. Move the ORDER BY to the outer query.",
+			})
+		}
+	}
+	return suggestions
+}
+
+// ---------------------------------------------------------------------------
+// OPT-012: Implicit Type Conversion (CAST on column in WHERE)
+// ---------------------------------------------------------------------------
+
+// ImplicitTypeConversionRule detects CAST expressions wrapping a column in WHERE conditions.
+// Wrapping a column in CAST/CONVERT prevents the database from using an index on that column.
+type ImplicitTypeConversionRule struct{}
+
+func (r *ImplicitTypeConversionRule) ID() string   { return "OPT-012" }
+func (r *ImplicitTypeConversionRule) Name() string { return "Implicit Type Conversion in WHERE" }
+func (r *ImplicitTypeConversionRule) Description() string {
+	return "CAST/CONVERT wrapping a column in a WHERE clause prevents index use and causes full table scans."
+}
+
+func (r *ImplicitTypeConversionRule) Analyze(stmt ast.Statement) []Suggestion {
+	sel, ok := stmt.(*ast.SelectStatement)
+	if !ok || sel.Where == nil {
+		return nil
+	}
+	if containsCastExprInWhere(sel.Where) {
+		return []Suggestion{{
+			RuleID:   r.ID(),
+			Severity: SeverityWarning,
+			Message:  "CAST/CONVERT wrapping a column in WHERE prevents index usage",
+			Detail:   "Casting a column in a WHERE comparison forces a full table scan. Cast the literal value to match the column type instead: column = CAST(value AS column_type).",
+		}}
+	}
+	return nil
+}
+
+// containsCastExprInWhere recursively checks if a WHERE expression contains a
+// CastExpression wrapping an Identifier (i.e., CAST(col AS type)).
+func containsCastExprInWhere(expr ast.Expression) bool {
+	if expr == nil {
+		return false
+	}
+	switch v := expr.(type) {
+	case *ast.CastExpression:
+		// CAST wrapping a column identifier
+		if _, ok := v.Expr.(*ast.Identifier); ok {
+			return true
+		}
+	case *ast.BinaryExpression:
+		return containsCastExprInWhere(v.Left) || containsCastExprInWhere(v.Right)
+	case *ast.UnaryExpression:
+		return containsCastExprInWhere(v.Expr)
+	}
+	return false
+}
+
+// ---------------------------------------------------------------------------
+// OPT-013: OR-to-IN Conversion
+// ---------------------------------------------------------------------------
+
+// OrToInConversionRule detects three or more OR equality conditions on the same column.
+// col = A OR col = B OR col = C is more readable and sometimes faster as col IN (A, B, C).
+type OrToInConversionRule struct{}
+
+func (r *OrToInConversionRule) ID() string   { return "OPT-013" }
+func (r *OrToInConversionRule) Name() string { return "OR Conditions on Same Column" }
+func (r *OrToInConversionRule) Description() string {
+	return "Three or more OR equality conditions on the same column should be rewritten as IN (...)."
+}
+
+func (r *OrToInConversionRule) Analyze(stmt ast.Statement) []Suggestion {
+	sel, ok := stmt.(*ast.SelectStatement)
+	if !ok || sel.Where == nil {
+		return nil
+	}
+	col, count := collectOrEqualityColumn(sel.Where)
+	if count >= 3 && col != "" {
+		return []Suggestion{{
+			RuleID:       r.ID(),
+			Severity:     SeverityInfo,
+			Message:      fmt.Sprintf("Column %q has %d OR equality conditions — consider using IN (...)", col, count),
+			Detail:       "Multiple OR conditions on the same column are equivalent to IN (...) but harder to read and may be less efficient.",
+			SuggestedSQL: fmt.Sprintf("WHERE %s IN (...)", col),
+		}}
+	}
+	return nil
+}
+
+// collectOrEqualityColumn traverses an OR chain and returns the column name and count
+// if all equality conditions in the OR chain reference the same column.
+// Returns ("", 0) if conditions are on different columns or the pattern is not matched.
+func collectOrEqualityColumn(expr ast.Expression) (string, int) {
+	bin, ok := expr.(*ast.BinaryExpression)
+	if !ok {
+		return "", 0
+	}
+
+	if strings.ToUpper(bin.Operator) == "OR" {
+		leftCol, leftCount := collectOrEqualityColumn(bin.Left)
+		rightCol, rightCount := collectOrEqualityColumn(bin.Right)
+
+		// Both sides must be on the same column
+		if leftCol == "" || rightCol == "" {
+			return "", 0
+		}
+		if leftCol != rightCol {
+			return "", 0
+		}
+		return leftCol, leftCount + rightCount
+	}
+
+	if bin.Operator == "=" {
+		if id, ok := bin.Left.(*ast.Identifier); ok {
+			return id.Name, 1
+		}
+	}
+
+	return "", 0
+}
+
+// ---------------------------------------------------------------------------
+// OPT-014: NOT IN Subquery NULL Risk
+// ---------------------------------------------------------------------------
+
+// NotInSubqueryNullRule flags NOT IN (subquery) patterns.
+// If the subquery returns any NULL, the entire NOT IN evaluates to an empty result set.
+type NotInSubqueryNullRule struct{}
+
+func (r *NotInSubqueryNullRule) ID() string   { return "OPT-014" }
+func (r *NotInSubqueryNullRule) Name() string { return "NOT IN With Subquery NULL Risk" }
+func (r *NotInSubqueryNullRule) Description() string {
+	return "NOT IN (subquery) returns empty set if the subquery produces any NULL. Use NOT EXISTS or LEFT JOIN ... IS NULL instead."
+}
+
+func (r *NotInSubqueryNullRule) Analyze(stmt ast.Statement) []Suggestion {
+	sel, ok := stmt.(*ast.SelectStatement)
+	if !ok || sel.Where == nil {
+		return nil
+	}
+	if containsNotInSubquery(sel.Where) {
+		return []Suggestion{{
+			RuleID:       r.ID(),
+			Severity:     SeverityWarning,
+			Message:      "NOT IN (subquery) returns empty result if the subquery has any NULL values",
+			Detail:       "If the subquery column is nullable, NOT IN returns no rows whenever any NULL appears. Use NOT EXISTS (SELECT 1 FROM ... WHERE ...) or a LEFT JOIN ... WHERE right.id IS NULL for correct behavior.",
+			SuggestedSQL: "WHERE NOT EXISTS (SELECT 1 FROM ... WHERE col = outer.col)",
+		}}
+	}
+	return nil
+}
+
+// containsNotInSubquery checks if an expression is or contains NOT IN (subquery).
+func containsNotInSubquery(expr ast.Expression) bool {
+	if expr == nil {
+		return false
+	}
+	switch v := expr.(type) {
+	case *ast.InExpression:
+		if v.Not && v.Subquery != nil {
+			return true
+		}
+	case *ast.BinaryExpression:
+		return containsNotInSubquery(v.Left) || containsNotInSubquery(v.Right)
+	case *ast.UnaryExpression:
+		return containsNotInSubquery(v.Expr)
+	}
+	return false
+}
+
+// ---------------------------------------------------------------------------
+// OPT-015: Missing LIMIT on Ordered Query
+// ---------------------------------------------------------------------------
+
+// MissingLimitRule flags SELECT queries with ORDER BY but no LIMIT/FETCH/TOP.
+// Without a LIMIT, the database must sort the entire result set.
+type MissingLimitRule struct{}
+
+func (r *MissingLimitRule) ID() string   { return "OPT-015" }
+func (r *MissingLimitRule) Name() string { return "Missing LIMIT on Ordered Query" }
+func (r *MissingLimitRule) Description() string {
+	return "SELECT with ORDER BY but no LIMIT/FETCH/TOP sorts the full result set, which can be slow on large tables."
+}
+
+func (r *MissingLimitRule) Analyze(stmt ast.Statement) []Suggestion {
+	sel, ok := stmt.(*ast.SelectStatement)
+	if !ok {
+		return nil
+	}
+	hasLimit := sel.Limit != nil || sel.Fetch != nil || sel.Top != nil
+	if len(sel.OrderBy) > 0 && !hasLimit {
+		return []Suggestion{{
+			RuleID:       r.ID(),
+			Severity:     SeverityInfo,
+			Message:      "SELECT with ORDER BY but no LIMIT sorts the full result set",
+			Detail:       "Without a LIMIT clause, the database must sort every matching row before returning results. Add LIMIT N to cap the result set at a known maximum.",
+			SuggestedSQL: "SELECT ... ORDER BY ... LIMIT 100",
+		}}
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// OPT-016: Unused Column Alias
+// ---------------------------------------------------------------------------
+
+// UnusedAliasRule detects column aliases defined in the SELECT list that are never
+// referenced in ORDER BY or HAVING clauses.
+type UnusedAliasRule struct{}
+
+func (r *UnusedAliasRule) ID() string   { return "OPT-016" }
+func (r *UnusedAliasRule) Name() string { return "Unused Column Alias" }
+func (r *UnusedAliasRule) Description() string {
+	return "Column aliases defined in SELECT but never referenced in ORDER BY or HAVING add noise and may indicate a bug."
+}
+
+func (r *UnusedAliasRule) Analyze(stmt ast.Statement) []Suggestion {
+	sel, ok := stmt.(*ast.SelectStatement)
+	if !ok {
+		return nil
+	}
+
+	// Collect all aliases defined in the SELECT list
+	aliases := make(map[string]bool)
+	for _, col := range sel.Columns {
+		if aliased, ok := col.(*ast.AliasedExpression); ok && aliased.Alias != "" {
+			aliases[strings.ToLower(aliased.Alias)] = false // false = not yet used
+		}
+	}
+
+	if len(aliases) == 0 {
+		return nil
+	}
+
+	// Mark aliases referenced in ORDER BY
+	for _, ob := range sel.OrderBy {
+		markAliasUsed(ob.Expression, aliases)
+	}
+	// Mark aliases referenced in HAVING
+	markAliasUsed(sel.Having, aliases)
+
+	// Report aliases that are never referenced
+	var suggestions []Suggestion
+	for alias, used := range aliases {
+		if !used {
+			suggestions = append(suggestions, Suggestion{
+				RuleID:   r.ID(),
+				Severity: SeverityInfo,
+				Message:  fmt.Sprintf("Column alias %q is defined but never referenced in ORDER BY or HAVING", alias),
+				Detail:   "Unused aliases add noise. If the alias is intentional for the caller, this warning can be ignored. Otherwise, check whether ORDER BY references should use the alias.",
+			})
+		}
+	}
+	return suggestions
+}
+
+// markAliasUsed walks an expression tree and marks any identifier that matches
+// a known alias as used.
+func markAliasUsed(expr ast.Expression, aliases map[string]bool) {
+	if expr == nil {
+		return
+	}
+	switch v := expr.(type) {
+	case *ast.Identifier:
+		key := strings.ToLower(v.Name)
+		if _, exists := aliases[key]; exists {
+			aliases[key] = true
+		}
+	case *ast.BinaryExpression:
+		markAliasUsed(v.Left, aliases)
+		markAliasUsed(v.Right, aliases)
+	case *ast.UnaryExpression:
+		markAliasUsed(v.Expr, aliases)
+	case *ast.FunctionCall:
+		for _, arg := range v.Arguments {
+			markAliasUsed(arg, aliases)
+		}
+	case *ast.AliasedExpression:
+		markAliasUsed(v.Expr, aliases)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// OPT-017: UNION Instead of UNION ALL
+// ---------------------------------------------------------------------------
+
+// UnionDeduplicationRule warns when UNION (without ALL) is used.
+// UNION deduplicates results by performing an internal sort or hash; UNION ALL avoids this.
+type UnionDeduplicationRule struct{}
+
+func (r *UnionDeduplicationRule) ID() string   { return "OPT-017" }
+func (r *UnionDeduplicationRule) Name() string { return "UNION Instead of UNION ALL" }
+func (r *UnionDeduplicationRule) Description() string {
+	return "UNION deduplicates results requiring a full sort or hash; use UNION ALL if duplicates are acceptable."
+}
+
+func (r *UnionDeduplicationRule) Analyze(stmt ast.Statement) []Suggestion {
+	op, ok := stmt.(*ast.SetOperation)
+	if !ok {
+		return nil
+	}
+	if strings.ToUpper(op.Operator) == "UNION" && !op.All {
+		return []Suggestion{{
+			RuleID:       r.ID(),
+			Severity:     SeverityInfo,
+			Message:      "UNION deduplicates results — use UNION ALL if duplicates are acceptable",
+			Detail:       "UNION requires sorting or hashing the combined result set to remove duplicates, adding significant overhead. If the queries cannot produce duplicates, or duplicates are acceptable, use UNION ALL for better performance.",
+			SuggestedSQL: "Replace UNION with UNION ALL",
+		}}
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// OPT-018: COUNT(DISTINCT col) Where COUNT(*) May Suffice
+// ---------------------------------------------------------------------------
+
+// CountStarRule flags COUNT(DISTINCT col) in SELECT lists.
+// COUNT(DISTINCT col) is significantly more expensive than COUNT(*) or COUNT(col)
+// because it requires sorting or hashing the distinct values.
+type CountStarRule struct{}
+
+func (r *CountStarRule) ID() string   { return "OPT-018" }
+func (r *CountStarRule) Name() string { return "COUNT(DISTINCT col) Overhead" }
+func (r *CountStarRule) Description() string {
+	return "COUNT(DISTINCT col) requires sorting/hashing all distinct values — verify DISTINCT is necessary."
+}
+
+func (r *CountStarRule) Analyze(stmt ast.Statement) []Suggestion {
+	sel, ok := stmt.(*ast.SelectStatement)
+	if !ok {
+		return nil
+	}
+	var suggestions []Suggestion
+	for _, col := range sel.Columns {
+		inner := col
+		if aliased, ok := col.(*ast.AliasedExpression); ok {
+			inner = aliased.Expr
+		}
+		if fn, ok := inner.(*ast.FunctionCall); ok {
+			if strings.ToUpper(fn.Name) == "COUNT" && fn.Distinct {
+				suggestions = append(suggestions, Suggestion{
+					RuleID:       r.ID(),
+					Severity:     SeverityInfo,
+					Message:      "COUNT(DISTINCT col) requires hashing all distinct values — ensure DISTINCT is necessary",
+					Detail:       "COUNT(DISTINCT col) is significantly more expensive than COUNT(*) or COUNT(col) because it must enumerate unique values. Verify that deduplication is actually required for correctness.",
+					SuggestedSQL: "Consider COUNT(*) or COUNT(col) if rows are already unique in this context",
+				})
+			}
+		}
+	}
+	return suggestions
+}
+
+// ---------------------------------------------------------------------------
+// OPT-019: Deep Subquery Nesting
+// ---------------------------------------------------------------------------
+
+// DeepSubqueryNestingRule flags queries with more than 3 levels of subquery nesting.
+// Deeply nested subqueries are difficult to optimize and should be rewritten with CTEs.
+type DeepSubqueryNestingRule struct{}
+
+func (r *DeepSubqueryNestingRule) ID() string   { return "OPT-019" }
+func (r *DeepSubqueryNestingRule) Name() string { return "Deep Subquery Nesting" }
+func (r *DeepSubqueryNestingRule) Description() string {
+	return "More than 3 levels of subquery nesting is hard for the optimizer — consider CTEs or JOINs."
+}
+
+func (r *DeepSubqueryNestingRule) Analyze(stmt ast.Statement) []Suggestion {
+	depth := maxSubqueryDepth(stmt, 0)
+	if depth > 3 {
+		return []Suggestion{{
+			RuleID:       r.ID(),
+			Severity:     SeverityWarning,
+			Message:      fmt.Sprintf("Query has %d levels of subquery nesting — consider rewriting with CTEs", depth),
+			Detail:       "Deeply nested subqueries are hard for both developers to read and query optimizers to plan efficiently. Rewrite as a sequence of CTEs (WITH clauses) to improve readability and enable better optimization.",
+			SuggestedSQL: "WITH cte1 AS (...), cte2 AS (...) SELECT ... FROM cte2",
+		}}
+	}
+	return nil
+}
+
+// maxSubqueryDepth returns the maximum subquery nesting depth starting from a statement.
+func maxSubqueryDepth(node interface{}, depth int) int {
+	if depth > 15 {
+		return depth // guard against pathological inputs
+	}
+
+	switch v := node.(type) {
+	case *ast.SelectStatement:
+		max := depth
+		for _, col := range v.Columns {
+			if d := maxSubqueryDepthExpr(col, depth); d > max {
+				max = d
+			}
+		}
+		if d := maxSubqueryDepthExpr(v.Where, depth); d > max {
+			max = d
+		}
+		if d := maxSubqueryDepthExpr(v.Having, depth); d > max {
+			max = d
+		}
+		return max
+
+	case *ast.SetOperation:
+		left := maxSubqueryDepth(v.Left, depth)
+		right := maxSubqueryDepth(v.Right, depth)
+		if left > right {
+			return left
+		}
+		return right
+	}
+	return depth
+}
+
+// maxSubqueryDepthExpr computes the maximum subquery depth starting from an expression.
+func maxSubqueryDepthExpr(expr ast.Expression, depth int) int {
+	if expr == nil || depth > 15 {
+		return depth
+	}
+
+	switch v := expr.(type) {
+	case *ast.SubqueryExpression:
+		return maxSubqueryDepth(v.Subquery, depth+1)
+
+	case *ast.InExpression:
+		if v.Subquery != nil {
+			return maxSubqueryDepth(v.Subquery, depth+1)
+		}
+
+	case *ast.ExistsExpression:
+		return maxSubqueryDepth(v.Subquery, depth+1)
+
+	case *ast.BinaryExpression:
+		left := maxSubqueryDepthExpr(v.Left, depth)
+		right := maxSubqueryDepthExpr(v.Right, depth)
+		if left > right {
+			return left
+		}
+		return right
+
+	case *ast.AliasedExpression:
+		return maxSubqueryDepthExpr(v.Expr, depth)
+
+	case *ast.FunctionCall:
+		max := depth
+		for _, arg := range v.Arguments {
+			if d := maxSubqueryDepthExpr(arg, depth); d > max {
+				max = d
+			}
+		}
+		return max
+	}
+
+	return depth
+}
+
+// ---------------------------------------------------------------------------
+// OPT-020: Explicit Cross Join / Cartesian Product
+// ---------------------------------------------------------------------------
+
+// ExplicitCrossJoinRule detects explicit CROSS JOIN clauses (without a join condition).
+// CROSS JOIN produces a cartesian product which is usually unintentional.
+type ExplicitCrossJoinRule struct{}
+
+func (r *ExplicitCrossJoinRule) ID() string   { return "OPT-020" }
+func (r *ExplicitCrossJoinRule) Name() string { return "Explicit Cross Join" }
+func (r *ExplicitCrossJoinRule) Description() string {
+	return "An explicit CROSS JOIN without a filter condition produces a cartesian product of all rows from both tables."
+}
+
+func (r *ExplicitCrossJoinRule) Analyze(stmt ast.Statement) []Suggestion {
+	sel, ok := stmt.(*ast.SelectStatement)
+	if !ok {
+		return nil
+	}
+	var suggestions []Suggestion
+	for _, j := range sel.Joins {
+		if strings.ToUpper(j.Type) == "CROSS" && j.Condition == nil {
+			suggestions = append(suggestions, Suggestion{
+				RuleID:   r.ID(),
+				Severity: SeverityWarning,
+				Message:  "CROSS JOIN produces a cartesian product — ensure this is intentional",
+				Detail:   "A CROSS JOIN combines every row from the left table with every row from the right table, producing rows_left × rows_right output rows. This is rarely intended. Add an ON condition to make it a standard JOIN, or use the explicit CROSS JOIN only when a cartesian product is genuinely needed.",
+			})
+		}
+	}
+	return suggestions
+}


### PR DESCRIPTION
## Summary

Closes #453. Expands the `pkg/advisor` query optimizer from 8 built-in rules to 20, covering N+1 patterns, NULL risks, redundant operations, and cartesian products.

- **OPT-009** `CorrelatedSubqueryInSelectRule` — subquery in SELECT list causes N+1 execution per row
- **OPT-010** `HavingWithoutGroupByRule` — HAVING without GROUP BY treats entire table as one group
- **OPT-011** `RedundantOrderByInCTERule` — ORDER BY inside CTE without LIMIT is ignored by most DBs
- **OPT-012** `ImplicitTypeConversionRule` — CAST/CONVERT wrapping a column in WHERE prevents index use
- **OPT-013** `OrToInConversionRule` — 3+ OR equality conditions on same column → suggest IN (...)
- **OPT-014** `NotInSubqueryNullRule` — NOT IN (subquery) returns empty if subquery has any NULL
- **OPT-015** `MissingLimitRule` — ORDER BY without LIMIT sorts the full result set
- **OPT-016** `UnusedAliasRule` — column alias defined in SELECT but never used in ORDER BY/HAVING
- **OPT-017** `UnionDeduplicationRule` — UNION (non-ALL) adds deduplication sort overhead
- **OPT-018** `CountStarRule` — COUNT(DISTINCT col) is more expensive than COUNT(*); verify necessity
- **OPT-019** `DeepSubqueryNestingRule` — subquery depth >3 levels → suggest CTEs
- **OPT-020** `ExplicitCrossJoinRule` — explicit CROSS JOIN without condition produces cartesian product

## Implementation details

- All rules implement the existing `Rule` interface; stateless and race-safe
- Implementations in `/pkg/advisor/rules_advanced.go`
- Tests in `/pkg/advisor/advisor_advanced_test.go` (written first — TDD)
- `DefaultRules()` updated to include all 20 rules
- Existing `TestDefaultRules` and `TestRuleMetadata` updated for new count (8 → 20)
- AST types used: `CastExpression` (OPT-012), `InExpression.Not` + `Subquery` (OPT-014), `WithClause.CTEs` (OPT-011), `SetOperation.All` (OPT-017), `FunctionCall.Distinct` (OPT-018), `JoinClause.Type` (OPT-020)

## Test plan

- [x] `go test ./pkg/advisor/... -v` — all tests pass
- [x] `go test -race ./pkg/advisor/... -timeout 60s` — no race conditions
- [x] Pre-commit hooks pass (fmt, vet, full short test suite)
- [x] Each rule has positive violation test + negative no-violation test + metadata test
- [x] Integration tests verify new rules fire through the full `Optimizer.AnalyzeSQL()` path

🤖 Generated with [Claude Code](https://claude.com/claude-code)