### PR TITLE
feat(parser): Snowflake LIKE ANY/ALL and ILIKE ANY/ALL (#483)

### DIFF
--- a/pkg/sql/parser/expressions_operators.go
+++ b/pkg/sql/parser/expressions_operators.go
@@ -110,6 +110,30 @@ func (p *Parser) parseComparisonExpression() (ast.Expression, error) {
 		}
 		p.advance() // Consume LIKE/ILIKE
 
+		// Snowflake LIKE ANY / LIKE ALL / ILIKE ANY / ILIKE ALL:
+		//   expr [NOT] LIKE ANY ('pattern1', 'pattern2', ...)
+		//   expr [NOT] ILIKE ALL ('%a%', '%b%')
+		// The ANY/ALL quantifier is followed by a parenthesised tuple.
+		if p.isType(models.TokenTypeAny) || p.isType(models.TokenTypeAll) {
+			quantifier := strings.ToUpper(p.currentToken.Token.Value)
+			operator = strings.ToUpper(operator) + " " + quantifier
+			p.advance() // Consume ANY/ALL
+			// Expect a tuple: (pattern, pattern, ...)
+			if !p.isType(models.TokenTypeLParen) {
+				return nil, p.expectedError("( after " + quantifier)
+			}
+			tuple, err := p.parsePrimaryExpression()
+			if err != nil {
+				return nil, err
+			}
+			return &ast.BinaryExpression{
+				Left:     left,
+				Operator: operator,
+				Right:    tuple,
+				Not:      notPrefix,
+			}, nil
+		}
+
 		// Parse pattern
 		pattern, err := p.parsePrimaryExpression()
 		if err != nil {

--- a/pkg/sql/parser/snowflake_like_any_all_test.go
+++ b/pkg/sql/parser/snowflake_like_any_all_test.go
@@ -1,0 +1,32 @@
+// Copyright 2026 GoSQLX Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+
+package parser_test
+
+import (
+	"testing"
+
+	"github.com/ajitpratap0/GoSQLX/pkg/gosqlx"
+	"github.com/ajitpratap0/GoSQLX/pkg/sql/keywords"
+)
+
+// TestSnowflakeLikeAnyAll verifies LIKE ANY/ALL and ILIKE ANY/ALL parse in
+// the Snowflake dialect. Regression for #483.
+func TestSnowflakeLikeAnyAll(t *testing.T) {
+	queries := map[string]string{
+		"like_any":      `SELECT * FROM users WHERE name LIKE ANY ('%alice%', '%bob%')`,
+		"like_all":      `SELECT * FROM users WHERE name LIKE ALL ('%a%', '%b%')`,
+		"ilike_any":     `SELECT * FROM events WHERE msg ILIKE ANY ('%error%', '%warn%')`,
+		"not_like_any":  `SELECT * FROM users WHERE name NOT LIKE ANY ('%test%', '%demo%')`,
+		"not_ilike_all": `SELECT * FROM users WHERE name NOT ILIKE ALL ('%a%', '%b%')`,
+	}
+	for name, q := range queries {
+		q := q
+		t.Run(name, func(t *testing.T) {
+			if _, err := gosqlx.ParseWithDialect(q, keywords.DialectSnowflake); err != nil {
+				t.Fatalf("parse failed: %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
Adds Snowflake \`LIKE ANY/ALL\` and \`ILIKE ANY/ALL\` pattern matching with tuple lists.

### What now parses
- \`WHERE name LIKE ANY ('%alice%', '%bob%')\`
- \`WHERE name LIKE ALL ('%a%', '%b%')\`
- \`WHERE msg ILIKE ANY ('%error%', '%warn%')\`
- \`WHERE name NOT LIKE ANY ('%test%', '%demo%')\`

### Implementation
After consuming \`LIKE\`/\`ILIKE\`, check for \`ANY\`/\`ALL\` quantifier tokens. If present, compose operator as \`"LIKE ANY"\` / \`"ILIKE ALL"\`, then parse the \`(...)\` tuple via the existing \`parsePrimaryExpression\` (which handles parenthesised tuples). Result is a standard \`BinaryExpression\` with the quantified operator string and a tuple RHS.

## Test plan
- [x] \`TestSnowflakeLikeAnyAll\`: 5 shapes including NOT variants
- [x] \`go test -race ./pkg/sql/parser/ ./pkg/gosqlx/\` green

Part of #483.

🤖 Generated with [Claude Code](https://claude.com/claude-code)