### PR TITLE
feat(parser): ClickHouse WITH TOTALS / LIMIT BY / ANY JOIN / DEFAULT ident (#482)

### DIFF
--- a/pkg/sql/parser/clickhouse_misc_fixes_test.go
+++ b/pkg/sql/parser/clickhouse_misc_fixes_test.go
@@ -1,0 +1,77 @@
+// Copyright 2026 GoSQLX Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+
+package parser_test
+
+import (
+	"testing"
+
+	"github.com/ajitpratap0/GoSQLX/pkg/gosqlx"
+	"github.com/ajitpratap0/GoSQLX/pkg/sql/keywords"
+)
+
+// TestClickHouseWithTotals verifies GROUP BY ... WITH TOTALS parses.
+func TestClickHouseWithTotals(t *testing.T) {
+	queries := []string{
+		`SELECT status, count() FROM events GROUP BY status WITH TOTALS`,
+		`SELECT status, count() FROM events GROUP BY status WITH TOTALS ORDER BY status`,
+	}
+	for _, q := range queries {
+		t.Run(q[:40], func(t *testing.T) {
+			if _, err := gosqlx.ParseWithDialect(q, keywords.DialectClickHouse); err != nil {
+				t.Fatalf("parse failed: %v", err)
+			}
+		})
+	}
+}
+
+// TestClickHouseLimitBy verifies LIMIT N [OFFSET M] BY expr parses.
+func TestClickHouseLimitBy(t *testing.T) {
+	queries := []string{
+		`SELECT user_id, event FROM events ORDER BY ts LIMIT 3 BY user_id`,
+		`SELECT user_id, event FROM events ORDER BY ts LIMIT 3 OFFSET 1 BY user_id`,
+		`SELECT user_id, event, ts FROM events ORDER BY ts LIMIT 5 BY user_id, event`,
+	}
+	for _, q := range queries {
+		t.Run(q[:40], func(t *testing.T) {
+			if _, err := gosqlx.ParseWithDialect(q, keywords.DialectClickHouse); err != nil {
+				t.Fatalf("parse failed: %v", err)
+			}
+		})
+	}
+}
+
+// TestClickHouseAnyJoin verifies the ANY/ALL join strictness prefix parses.
+func TestClickHouseAnyJoin(t *testing.T) {
+	queries := map[string]string{
+		"any_left":  `SELECT * FROM a ANY LEFT JOIN b ON a.id = b.id`,
+		"any_inner": `SELECT * FROM a ANY INNER JOIN b ON a.id = b.id`,
+		"all_inner": `SELECT * FROM a ALL INNER JOIN b ON a.id = b.id`,
+		"asof":      `SELECT * FROM a ASOF JOIN b ON a.id = b.id AND a.ts >= b.ts`,
+	}
+	for name, q := range queries {
+		q := q
+		t.Run(name, func(t *testing.T) {
+			if _, err := gosqlx.ParseWithDialect(q, keywords.DialectClickHouse); err != nil {
+				t.Fatalf("parse failed: %v", err)
+			}
+		})
+	}
+}
+
+// TestClickHouseDefaultAsIdentifier verifies DEFAULT can be used as a column
+// name and DATABASES as a qualified table name in ClickHouse.
+func TestClickHouseDefaultAsIdentifier(t *testing.T) {
+	queries := []string{
+		`SELECT default FROM t`,
+		`SELECT database, default FROM system.databases`,
+	}
+	for _, q := range queries {
+		t.Run(q, func(t *testing.T) {
+			if _, err := gosqlx.ParseWithDialect(q, keywords.DialectClickHouse); err != nil {
+				t.Fatalf("parse failed: %v", err)
+			}
+		})
+	}
+}

--- a/pkg/sql/parser/parser.go
+++ b/pkg/sql/parser/parser.go
@@ -1063,7 +1063,7 @@ func (p *Parser) isNonReservedKeyword() bool {
 		return true
 	case models.TokenTypeTable, models.TokenTypeIndex, models.TokenTypeView,
 		models.TokenTypeKey, models.TokenTypeColumn, models.TokenTypeDatabase,
-		models.TokenTypePartition, models.TokenTypeRows:
+		models.TokenTypePartition, models.TokenTypeRows, models.TokenTypeDefault:
 		// DDL keywords that are commonly used as quoted identifiers in MySQL (backtick)
 		// and SQL Server (bracket) dialects, and as plain column names in ClickHouse
 		// system tables (system.parts.partition, system.replicas.table,
@@ -1073,7 +1073,7 @@ func (p *Parser) isNonReservedKeyword() bool {
 		// Token may have generic Type; check value for specific keywords
 		switch strings.ToUpper(p.currentToken.Token.Value) {
 		case "TARGET", "SOURCE", "MATCHED", "VALUE", "NAME", "TYPE", "STATUS",
-			"TABLES":
+			"TABLES", "DATABASES":
 			return true
 		}
 	}
@@ -1109,6 +1109,11 @@ func (p *Parser) isJoinKeyword() bool {
 	}
 	// ClickHouse: GLOBAL JOIN — GLOBAL is TokenTypeKeyword, not a dedicated join token
 	if p.dialect == string(keywords.DialectClickHouse) && p.isTokenMatch("GLOBAL") {
+		return true
+	}
+	// ClickHouse: ANY / ALL as join strictness prefix (ANY LEFT JOIN, ALL INNER JOIN)
+	if p.dialect == string(keywords.DialectClickHouse) &&
+		(p.isType(models.TokenTypeAny) || p.isType(models.TokenTypeAll)) {
 		return true
 	}
 	return false

--- a/pkg/sql/parser/select.go
+++ b/pkg/sql/parser/select.go
@@ -179,6 +179,22 @@ func (p *Parser) parseSelectStatement() (ast.Statement, error) {
 		return nil, err
 	}
 
+	// ClickHouse LIMIT BY: `LIMIT N [OFFSET M] BY expr [, expr]...`
+	// The LIMIT and OFFSET values were already consumed above; if the next
+	// token is BY, consume the BY-expression list (permissive, not modeled).
+	if p.dialect == string(keywords.DialectClickHouse) && p.isType(models.TokenTypeBy) {
+		p.advance() // Consume BY
+		for {
+			if _, err := p.parseExpression(); err != nil {
+				return nil, err
+			}
+			if !p.isType(models.TokenTypeComma) {
+				break
+			}
+			p.advance()
+		}
+	}
+
 	// FETCH FIRST / NEXT
 	if p.isType(models.TokenTypeFetch) {
 		if selectStmt.Fetch, err = p.parseFetchClause(); err != nil {

--- a/pkg/sql/parser/select_clauses.go
+++ b/pkg/sql/parser/select_clauses.go
@@ -182,6 +182,13 @@ func (p *Parser) parseJoinType() (string, bool, error) {
 		p.advance() // consume GLOBAL; fall through to standard join parsing
 	}
 
+	// ClickHouse ANY/ALL join strictness prefix — e.g. ANY LEFT JOIN, ALL INNER JOIN.
+	// The strictness modifier is consumed but not modeled on the AST.
+	if p.dialect == string(keywords.DialectClickHouse) &&
+		(p.isType(models.TokenTypeAny) || p.isType(models.TokenTypeAll)) {
+		p.advance()
+	}
+
 	if p.isType(models.TokenTypeNatural) {
 		isNatural = true
 		p.advance()
@@ -481,7 +488,7 @@ func (p *Parser) parseGroupByClause() ([]ast.Expression, error) {
 		p.advance()
 	}
 
-	// MySQL: GROUP BY col1 WITH ROLLUP / WITH CUBE
+	// MySQL / ClickHouse: GROUP BY col1 WITH ROLLUP / WITH CUBE / WITH TOTALS
 	if p.isType(models.TokenTypeWith) {
 		switch strings.ToUpper(p.peekToken().Token.Value) {
 		case "ROLLUP":
@@ -492,6 +499,11 @@ func (p *Parser) parseGroupByClause() ([]ast.Expression, error) {
 			p.advance() // Consume WITH
 			p.advance() // Consume CUBE
 			groupByExprs = []ast.Expression{&ast.CubeExpression{Expressions: groupByExprs}}
+		case "TOTALS":
+			// ClickHouse WITH TOTALS: adds a summary row with aggregate totals.
+			// Consumed but not modeled on the AST (follow-up).
+			p.advance() // Consume WITH
+			p.advance() // Consume TOTALS
 		}
 	}
 


### PR DESCRIPTION
## Summary
Four ClickHouse parser fixes from the QA residuals (#482): WITH TOTALS, LIMIT BY, ANY/ALL JOIN prefix, DEFAULT/DATABASES as identifiers.

## Test plan
- [x] 11 test shapes across 4 test functions, race-tested green

Part of #482.

🤖 Generated with [Claude Code](https://claude.com/claude-code)